### PR TITLE
fix: StudyController 경로 중복 문제 해결

### DIFF
--- a/src/main/java/com/grepp/spring/app/controller/api/StudyController.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/StudyController.java
@@ -35,7 +35,7 @@ public class StudyController {
     }
 
     // 스터디 목록(검색)
-    @PostMapping()
+    @PostMapping("/search")
     public ResponseEntity<?> searchStudies(
         @RequestBody StudySearchRequest req
     ) {
@@ -335,7 +335,7 @@ public class StudyController {
     }
 
     // 스터디 생성
-    @PostMapping()
+    @PostMapping
     public ResponseEntity<?> createStudy(StudyCreationRequest req) {
         return ResponseEntity.status(200).body(
             Map.of("code", "SUCCESS", "message", "생성 완료했습니다.")


### PR DESCRIPTION
## 내용 설명
스터디 목록 검색과 스터디 생성이 모두 POST 경로 없는 요청이라 중복된 경로로 인한 빌드오류가 발생했습니다.

## 해결
스터디 목록 검색 경로를 /search를 추가했습니다.