### PR TITLE
Feat: applicant 엔티티 구현 및 applicant 조회 기능 구현

### DIFF
--- a/src/main/java/com/grepp/spring/app/model/member/dto/response/ApplicantsResponse.java
+++ b/src/main/java/com/grepp/spring/app/model/member/dto/response/ApplicantsResponse.java
@@ -1,0 +1,27 @@
+package com.grepp.spring.app.model.member.dto.response;
+
+import com.grepp.spring.app.model.study.code.ApplicantState;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter @ToString
+@NoArgsConstructor
+public class ApplicantsResponse {
+
+    private Long applicantId;
+    private Long memberId;
+    private String name;
+    private ApplicantState state;
+    private String introduction;
+
+    public ApplicantsResponse(Long applicantId, Long memberId, String name, ApplicantState state,
+        String introduction) {
+        this.applicantId = applicantId;
+        this.memberId = memberId;
+        this.name = name;
+        this.state = state;
+        this.introduction = introduction;
+    }
+
+}

--- a/src/main/java/com/grepp/spring/app/model/study/StudyService.java
+++ b/src/main/java/com/grepp/spring/app/model/study/StudyService.java
@@ -1,0 +1,21 @@
+package com.grepp.spring.app.model.study;
+
+import com.grepp.spring.app.model.member.dto.response.ApplicantsResponse;
+import com.grepp.spring.app.model.study.repository.StudyRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class StudyService {
+
+    private final StudyRepository studyRepository;
+
+    @Transactional(readOnly = true)
+    public List<ApplicantsResponse> getApplicants(Long studyId) {
+        return studyRepository.findAllApplicants(studyId);
+    }
+
+}

--- a/src/main/java/com/grepp/spring/app/model/study/code/ApplicantState.java
+++ b/src/main/java/com/grepp/spring/app/model/study/code/ApplicantState.java
@@ -1,0 +1,5 @@
+package com.grepp.spring.app.model.study.code;
+
+public enum ApplicantState {
+    WAIT, ACCEPT, REJECT
+}

--- a/src/main/java/com/grepp/spring/app/model/study/entity/Applicant.java
+++ b/src/main/java/com/grepp/spring/app/model/study/entity/Applicant.java
@@ -1,11 +1,13 @@
 package com.grepp.spring.app.model.study.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.grepp.spring.app.model.member.entity.Member;
 import com.grepp.spring.app.model.study.code.ApplicantState;
 import com.grepp.spring.infra.entity.BaseEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -35,13 +37,13 @@ public class Applicant extends BaseEntity {
     private Study study;
 
     @Builder
-    public Applicant(Long id, ApplicantState state, String introduction, Study study,
-        Long memberId) {
+    public Applicant(Long id, ApplicantState state, String introduction, Long memberId,
+        Study study) {
         this.id = id;
         this.state = state;
         this.introduction = introduction;
-        this.study = study;
         this.memberId = memberId;
+        this.study = study;
     }
 
     protected void setStudy(Study study) {

--- a/src/main/java/com/grepp/spring/app/model/study/entity/Applicant.java
+++ b/src/main/java/com/grepp/spring/app/model/study/entity/Applicant.java
@@ -1,0 +1,51 @@
+package com.grepp.spring.app.model.study.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.grepp.spring.app.model.study.code.ApplicantState;
+import com.grepp.spring.infra.entity.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor
+public class Applicant extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private ApplicantState state;
+
+    private String introduction;
+
+    private Long memberId;
+
+    @ManyToOne @JsonIgnore
+    @JoinColumn(name = "study_id")
+    private Study study;
+
+    @Builder
+    public Applicant(Long id, ApplicantState state, String introduction, Study study,
+        Long memberId) {
+        this.id = id;
+        this.state = state;
+        this.introduction = introduction;
+        this.study = study;
+        this.memberId = memberId;
+    }
+
+    protected void setStudy(Study study) {
+        this.study = study;
+    }
+
+}

--- a/src/main/java/com/grepp/spring/app/model/study/entity/Applicant.java
+++ b/src/main/java/com/grepp/spring/app/model/study/entity/Applicant.java
@@ -29,7 +29,6 @@ public class Applicant extends BaseEntity {
     private ApplicantState state;
 
     private String introduction;
-
     private Long memberId;
 
     @ManyToOne @JsonIgnore
@@ -45,9 +44,4 @@ public class Applicant extends BaseEntity {
         this.memberId = memberId;
         this.study = study;
     }
-
-    protected void setStudy(Study study) {
-        this.study = study;
-    }
-
 }

--- a/src/main/java/com/grepp/spring/app/model/study/entity/Study.java
+++ b/src/main/java/com/grepp/spring/app/model/study/entity/Study.java
@@ -76,4 +76,13 @@ public class Study {
 
     @OneToMany(mappedBy = "study", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<StudySchedule> schedules = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "study", cascade = CascadeType.ALL)
+    private List<Applicant> applicants = new ArrayList<>();
+
+    public void addApplicant(Applicant applicant) {
+        this.applicants.add(applicant);
+        applicant.setStudy(this);
+    }
 }

--- a/src/main/java/com/grepp/spring/app/model/study/entity/Study.java
+++ b/src/main/java/com/grepp/spring/app/model/study/entity/Study.java
@@ -58,7 +58,6 @@ public class Study {
     @Enumerated(EnumType.STRING)
     private Status status;
 
-    @Lob
     private String notice;
 
     private String description;
@@ -76,13 +75,4 @@ public class Study {
 
     @OneToMany(mappedBy = "study", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<StudySchedule> schedules = new ArrayList<>();
-
-    @Builder.Default
-    @OneToMany(mappedBy = "study", cascade = CascadeType.ALL)
-    private List<Applicant> applicants = new ArrayList<>();
-
-    public void addApplicant(Applicant applicant) {
-        this.applicants.add(applicant);
-        applicant.setStudy(this);
-    }
 }

--- a/src/main/java/com/grepp/spring/app/model/study/entity/StudyGoal.java
+++ b/src/main/java/com/grepp/spring/app/model/study/entity/StudyGoal.java
@@ -19,7 +19,6 @@ public class StudyGoal {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long goalId;
 
-    @Lob
     private String content;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/grepp/spring/app/model/study/repository/StudyRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/study/repository/StudyRepository.java
@@ -1,0 +1,21 @@
+package com.grepp.spring.app.model.study.repository;
+
+import com.grepp.spring.app.model.member.dto.response.ApplicantsResponse;
+import com.grepp.spring.app.model.study.entity.Study;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface StudyRepository extends JpaRepository<Study, Long> {
+
+    @Query("SELECT new com.grepp.spring.app.model.member.dto.response."
+        + "ApplicantsResponse(a.id, a.member.id, a.member.nickname,"
+        + " a.state, a.introduction) " +
+        "FROM Applicant a " +
+        "JOIN a.member " +
+        "WHERE a.study.id = :studyId")
+    List<ApplicantsResponse> findAllApplicants(@Param("studyId") Long studyId);
+}

--- a/src/main/java/com/grepp/spring/app/model/study/service/StudyService.java
+++ b/src/main/java/com/grepp/spring/app/model/study/service/StudyService.java
@@ -1,4 +1,4 @@
-package com.grepp.spring.app.model.study;
+package com.grepp.spring.app.model.study.service;
 
 import com.grepp.spring.app.model.member.dto.response.ApplicantsResponse;
 import com.grepp.spring.app.model.study.repository.StudyRepository;

--- a/src/test/java/com/grepp/spring/app/model/study/StudyServiceTest.java
+++ b/src/test/java/com/grepp/spring/app/model/study/StudyServiceTest.java
@@ -4,6 +4,7 @@ package com.grepp.spring.app.model.study;
 import com.grepp.spring.app.model.member.dto.response.ApplicantsResponse;
 import com.grepp.spring.app.model.study.code.ApplicantState;
 import com.grepp.spring.app.model.study.repository.StudyRepository;
+import com.grepp.spring.app.model.study.service.StudyService;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/grepp/spring/app/model/study/StudyServiceTest.java
+++ b/src/test/java/com/grepp/spring/app/model/study/StudyServiceTest.java
@@ -1,0 +1,61 @@
+package com.grepp.spring.app.model.study;
+
+
+import com.grepp.spring.app.model.member.dto.response.ApplicantsResponse;
+import com.grepp.spring.app.model.study.code.ApplicantState;
+import com.grepp.spring.app.model.study.repository.StudyRepository;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class StudyServiceTest {
+
+    @Mock // Mock 객체로 만들 Repository
+    private StudyRepository studyRepository;
+
+    @InjectMocks // @Mock 객체를 주입받을 Service 객체
+    private StudyService studyService;
+
+    @Test
+    @DisplayName("Success Search - applicant list")
+    void getApplicants_success() {
+        // given
+        Long studyId = 1L;
+
+        // 가짜 데이터 리스트 생성
+        List<ApplicantsResponse> expectedResponses = Arrays.asList(
+            new ApplicantsResponse(101L, 201L, "test1", ApplicantState.WAIT, "I'm ready to study hard!"),
+            new ApplicantsResponse(102L, 202L, "test2", ApplicantState.ACCEPT, "Hi, I want to join here.")
+        );
+
+        // studyRepository.findAllApplicants(studyId) 메서드가 호출되면, expectedResponses 리스트를 반환
+        when(studyRepository.findAllApplicants(studyId)).thenReturn(expectedResponses);
+
+        // when
+        List<ApplicantsResponse> actualResponses = studyService.getApplicants(studyId);
+//        System.out.println(actualResponses.toString());
+
+        // then (결과 검증)
+        assertThat(actualResponses).isNotNull();
+        assertThat(actualResponses.size()).isEqualTo(2);
+        assertThat(actualResponses.get(0).getName()).isEqualTo("test1");
+        assertThat(actualResponses.get(1).getState()).isEqualTo(ApplicantState.ACCEPT);
+
+        // studyRepository.findAllApplicants(studyId)가 정확히 1번 호출되었는지 검증
+        verify(studyRepository, times(1)).findAllApplicants(studyId);
+    }
+
+
+
+}


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
스터디의 신청자에 대한 엔티티 구현
StudyService에서 스터디 신청자 조회 기능 구현

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
StudyService에서 findAllApplicants을 이용해서 StudyId를 이용해 해당 스터디에 신청한 신청자 목록을 가져오도록 했습니다.
JPA Alias를 이용해 ApplicantsResponse로 반환하도록 했고 Join은 member와 걸어두었습니다.

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
현재 정확한 반환값을 어떻게 할지 몰라 
<img width="338" height="273" alt="Screenshot 2025-07-11 at 11 54 54 AM" src="https://github.com/user-attachments/assets/d931b56e-9386-4881-ba85-d2a5a9b508b1" />
신청자의 수락상태를 변경하고 알림을 보내기 위해 applicantId가 필요하다 생각했고 
해당 유저의 마이페이지를 타 유저가 접속할 수 있으니 해당 기능을 위해 memberId를 넣어두었습니다. 
