### PR TITLE
Feat: 스터디 역할 확인 어노테이션 추가

### DIFF
--- a/src/main/java/com/grepp/spring/app/model/member/repository/StudyMemberRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/member/repository/StudyMemberRepository.java
@@ -1,5 +1,6 @@
 package com.grepp.spring.app.model.member.repository;
 
+import com.grepp.spring.app.model.member.code.StudyRole;
 import com.grepp.spring.app.model.member.entity.StudyMember;
 import io.lettuce.core.dynamic.annotation.Param;
 import java.util.List;
@@ -29,4 +30,9 @@ public interface StudyMemberRepository extends JpaRepository<StudyMember, Long> 
 
     @Query("SELECT sm FROM StudyMember sm JOIN FETCH sm.member WHERE sm.study.studyId = :studyId")
     List<StudyMember> findAllByStudyIdWithMember(@Param("studyId") Long studyId);
+
+
+    @Query("select sm.studyRole  from StudyMember sm "
+        + "where sm.study.studyId = :studyId and sm.member.id = :memberId")
+    Optional<StudyRole> findRoleByStudyAndMember(Long studyId, Long memberId);
 }

--- a/src/main/java/com/grepp/spring/app/model/study/service/StudyService.java
+++ b/src/main/java/com/grepp/spring/app/model/study/service/StudyService.java
@@ -278,6 +278,4 @@ public class StudyService {
         );
     }
 
-
-
 }

--- a/src/main/java/com/grepp/spring/infra/auth/jwt/TokenCookieFactory.java
+++ b/src/main/java/com/grepp/spring/infra/auth/jwt/TokenCookieFactory.java
@@ -7,8 +7,8 @@ public class TokenCookieFactory {
         return ResponseCookie.from(name, value)
                    .maxAge(expires)
                    .path("/")
-                   .httpOnly(true)             // HttpOnly
-                   .secure(false)
+                   .httpOnly(false)             // HttpOnly
+                   .secure(true)
                    .sameSite("None")
                    .build();
     }
@@ -17,8 +17,8 @@ public class TokenCookieFactory {
         return ResponseCookie.from(name, "")
                    .maxAge(0)
                    .path("/")
-                   .httpOnly(true)             // HttpOnly
-                   .secure(false)
+                   .httpOnly(false)             // HttpOnly
+                   .secure(true)
                    .sameSite("None")
                    .build();
     }

--- a/src/main/java/com/grepp/spring/infra/auth/jwt/TokenCookieFactory.java
+++ b/src/main/java/com/grepp/spring/infra/auth/jwt/TokenCookieFactory.java
@@ -9,7 +9,7 @@ public class TokenCookieFactory {
                    .path("/")
                    .httpOnly(true)             // HttpOnly
                    .secure(false)
-                   .sameSite("Lax")// Secure
+                   .sameSite("None")
                    .build();
     }
     
@@ -19,7 +19,7 @@ public class TokenCookieFactory {
                    .path("/")
                    .httpOnly(true)             // HttpOnly
                    .secure(false)
-                   .sameSite("Lax")// // Secure
+                   .sameSite("None")
                    .build();
     }
 }

--- a/src/main/java/com/grepp/spring/infra/auth/role/HasRoleInThisStudy.java
+++ b/src/main/java/com/grepp/spring/infra/auth/role/HasRoleInThisStudy.java
@@ -8,6 +8,6 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface OnlyThisStudyRole {
-    StudyRole value();
+public @interface HasRoleInThisStudy {
+    StudyRole[] value();
 }

--- a/src/main/java/com/grepp/spring/infra/auth/role/OnlyThisStudyRole.java
+++ b/src/main/java/com/grepp/spring/infra/auth/role/OnlyThisStudyRole.java
@@ -1,0 +1,13 @@
+package com.grepp.spring.infra.auth.role;
+
+import com.grepp.spring.app.model.member.code.StudyRole;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface OnlyThisStudyRole {
+    StudyRole value();
+}

--- a/src/main/java/com/grepp/spring/infra/auth/role/StudyRoleCheckAspect.java
+++ b/src/main/java/com/grepp/spring/infra/auth/role/StudyRoleCheckAspect.java
@@ -1,0 +1,53 @@
+package com.grepp.spring.infra.auth.role;
+
+import com.grepp.spring.app.model.member.code.StudyRole;
+import com.grepp.spring.app.model.member.repository.StudyMemberRepository;
+import com.grepp.spring.infra.util.SecurityUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.servlet.HandlerMapping;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class StudyRoleCheckAspect {
+
+    private final StudyMemberRepository studyMemberRepository;
+
+    @Before("@annotation(OnlyThisStudyRole)")
+    public void checkRole(JoinPoint joinPoint) throws AccessDeniedException {
+        Long memberId = SecurityUtil.getCurrentMemberId();
+
+        // HttpServletRequest 에서 studyId
+        ServletRequestAttributes requestAttributes = (ServletRequestAttributes) RequestContextHolder.currentRequestAttributes();
+        HttpServletRequest request = requestAttributes.getRequest();
+
+        // PathVariable로 넘어온 값들을 Map 형태로 가져옵니다.
+        Map<String, String> pathVariables = (Map<String, String>) request.getAttribute(
+            HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
+        Long studyId = Long.parseLong(pathVariables.get("studyId"));
+
+        // 허가된 역할
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        OnlyThisStudyRole checkStudyRole = signature.getMethod().getAnnotation(OnlyThisStudyRole.class);
+        StudyRole requiredRole = checkStudyRole.value();
+
+        // 실제 역할
+        StudyRole userRoleInStudy = studyMemberRepository.findRoleByStudyAndMember(studyId, memberId)
+            .orElseThrow(() -> new AccessDeniedException("해당 스터디에 가입되지않았습니다."));
+
+        if (!userRoleInStudy.equals(requiredRole)) {
+            throw new AccessDeniedException("해당 역할은 접근 권한이 없습니다.");
+        }
+    }
+
+}

--- a/src/main/java/com/grepp/spring/infra/auth/role/StudyRoleCheckAspect.java
+++ b/src/main/java/com/grepp/spring/infra/auth/role/StudyRoleCheckAspect.java
@@ -4,6 +4,7 @@ import com.grepp.spring.app.model.member.code.StudyRole;
 import com.grepp.spring.app.model.member.repository.StudyMemberRepository;
 import com.grepp.spring.infra.util.SecurityUtil;
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.Arrays;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.aspectj.lang.JoinPoint;
@@ -23,29 +24,32 @@ public class StudyRoleCheckAspect {
 
     private final StudyMemberRepository studyMemberRepository;
 
-    @Before("@annotation(OnlyThisStudyRole)")
+    @Before("@annotation(com.grepp.spring.infra.auth.role.HasRoleInThisStudy)")
     public void checkRole(JoinPoint joinPoint) throws AccessDeniedException {
         Long memberId = SecurityUtil.getCurrentMemberId();
 
-        // HttpServletRequest 에서 studyId
+        // HttpServletRequest 에서 studyId 획득
         ServletRequestAttributes requestAttributes = (ServletRequestAttributes) RequestContextHolder.currentRequestAttributes();
         HttpServletRequest request = requestAttributes.getRequest();
 
-        // PathVariable로 넘어온 값들을 Map 형태로 가져옵니다.
+        // PathVariable로 넘어온 값 획득
         Map<String, String> pathVariables = (Map<String, String>) request.getAttribute(
             HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
         Long studyId = Long.parseLong(pathVariables.get("studyId"));
 
         // 허가된 역할
         MethodSignature signature = (MethodSignature) joinPoint.getSignature();
-        OnlyThisStudyRole checkStudyRole = signature.getMethod().getAnnotation(OnlyThisStudyRole.class);
-        StudyRole requiredRole = checkStudyRole.value();
+        HasRoleInThisStudy checkStudyRole = signature.getMethod().getAnnotation(HasRoleInThisStudy.class);
+        StudyRole[] requiredRoles = checkStudyRole.value();
 
         // 실제 역할
         StudyRole userRoleInStudy = studyMemberRepository.findRoleByStudyAndMember(studyId, memberId)
             .orElseThrow(() -> new AccessDeniedException("해당 스터디에 가입되지않았습니다."));
 
-        if (!userRoleInStudy.equals(requiredRole)) {
+        boolean isAuthorized = Arrays.stream(requiredRoles)
+            .anyMatch(role -> role.equals(userRoleInStudy));
+
+        if (!isAuthorized) {
             throw new AccessDeniedException("해당 역할은 접근 권한이 없습니다.");
         }
     }

--- a/src/main/java/com/grepp/spring/infra/config/WebConfig.java
+++ b/src/main/java/com/grepp/spring/infra/config/WebConfig.java
@@ -14,11 +14,12 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-            .allowedOrigins(frontServer)
+            .allowedOrigins(frontServer, "http://localhost:3000")
             .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
             .allowedHeaders("*")
             .allowCredentials(true)
             .maxAge(3600);
     }
+
 }
 

--- a/src/main/java/com/grepp/spring/infra/error/AuthExceptionAdvice.java
+++ b/src/main/java/com/grepp/spring/infra/error/AuthExceptionAdvice.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -34,5 +35,15 @@ public class AuthExceptionAdvice {
         return ResponseEntity
                    .status(HttpStatus.UNAUTHORIZED)
                    .body(CommonResponse.error(ResponseCode.UNAUTHORIZED));
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<CommonResponse<String>> authExHandler(
+        AccessDeniedException ex
+    ) {
+        log.error(ex.getMessage(), ex);
+        return ResponseEntity
+            .status(HttpStatus.UNAUTHORIZED)
+            .body(CommonResponse.error(ResponseCode.UNAUTHORIZED));
     }
 }

--- a/src/main/java/com/grepp/spring/infra/response/CommonResponse.java
+++ b/src/main/java/com/grepp/spring/infra/response/CommonResponse.java
@@ -41,7 +41,7 @@ public record CommonResponse<T>(
         return new CommonResponse<>(code, message, null, null);
     }
 
-    public CommonResponse<T> withToken(String token) {
-        return new CommonResponse<>(this.code, this.message, this.data, token);
-    }
+//    public CommonResponse<T> withToken(String token) {
+//        return new CommonResponse<>(this.code, this.message, this.data, token);
+//    }
 }

--- a/src/main/java/com/grepp/spring/infra/response/CommonResponse.java
+++ b/src/main/java/com/grepp/spring/infra/response/CommonResponse.java
@@ -9,33 +9,39 @@ public record CommonResponse<T>(
     @Schema(description = "응답 메시지", example = "성공적으로 처리되었습니다.")
     String message,
     @Schema(description = "응답 데이터")
-    T data
+    T data,
+    @Schema(description = "JWT 액세스 토큰")
+    String accessToken
 ) {
     public static <T> CommonResponse<T> success(T data) {
-        return new CommonResponse<>(ResponseCode.SUCCESS.code(), ResponseCode.SUCCESS.message(), data);
+        return new CommonResponse<>(ResponseCode.SUCCESS.code(), ResponseCode.SUCCESS.message(), data, null);
     }
 
     public static <T> CommonResponse<T> success(T data, String message) {
-        return new CommonResponse<>(ResponseCode.SUCCESS.code(), message, data);
+        return new CommonResponse<>(ResponseCode.SUCCESS.code(), message, data, null);
     }
 
     public static <T> CommonResponse<T> noContent() {
-        return new CommonResponse<>(ResponseCode.SUCCESS.code(), ResponseCode.SUCCESS.message(), null);
+        return new CommonResponse<>(ResponseCode.SUCCESS.code(), ResponseCode.SUCCESS.message(), null, null);
     }
 
     public static <T> CommonResponse<T> noContent(SuccessCode message) {
-        return new CommonResponse<>(message.code(), message.message(), null);
+        return new CommonResponse<>(message.code(), message.message(), null, null);
     }
 
     public static <T> CommonResponse<T> error(ResponseCode code) {
-        return new CommonResponse<>(code.code(), code.message(), null);
+        return new CommonResponse<>(code.code(), code.message(), null, null);
     }
 
     public static <T> CommonResponse<T> error(ResponseCode code, T data) {
-        return new CommonResponse<>(code.code(), code.message(), data);
+        return new CommonResponse<>(code.code(), code.message(), data, null);
     }
 
     public static <T> CommonResponse<T> error(String code, String message) {
-        return new CommonResponse<>(code, message, null);
+        return new CommonResponse<>(code, message, null, null);
+    }
+
+    public CommonResponse<T> withToken(String token) {
+        return new CommonResponse<>(this.code, this.message, this.data, token);
     }
 }

--- a/src/main/java/com/grepp/spring/infra/response/CommonResponse.java
+++ b/src/main/java/com/grepp/spring/infra/response/CommonResponse.java
@@ -9,36 +9,36 @@ public record CommonResponse<T>(
     @Schema(description = "응답 메시지", example = "성공적으로 처리되었습니다.")
     String message,
     @Schema(description = "응답 데이터")
-    T data,
-    @Schema(description = "JWT 액세스 토큰")
-    String accessToken
+    T data
+//    @Schema(description = "JWT 액세스 토큰")
+//    String accessToken
 ) {
     public static <T> CommonResponse<T> success(T data) {
-        return new CommonResponse<>(ResponseCode.SUCCESS.code(), ResponseCode.SUCCESS.message(), data, null);
+        return new CommonResponse<>(ResponseCode.SUCCESS.code(), ResponseCode.SUCCESS.message(), data);
     }
 
     public static <T> CommonResponse<T> success(T data, String message) {
-        return new CommonResponse<>(ResponseCode.SUCCESS.code(), message, data, null);
+        return new CommonResponse<>(ResponseCode.SUCCESS.code(), message, data);
     }
 
     public static <T> CommonResponse<T> noContent() {
-        return new CommonResponse<>(ResponseCode.SUCCESS.code(), ResponseCode.SUCCESS.message(), null, null);
+        return new CommonResponse<>(ResponseCode.SUCCESS.code(), ResponseCode.SUCCESS.message(), null);
     }
 
     public static <T> CommonResponse<T> noContent(SuccessCode message) {
-        return new CommonResponse<>(message.code(), message.message(), null, null);
+        return new CommonResponse<>(message.code(), message.message(), null);
     }
 
     public static <T> CommonResponse<T> error(ResponseCode code) {
-        return new CommonResponse<>(code.code(), code.message(), null, null);
+        return new CommonResponse<>(code.code(), code.message(), null);
     }
 
     public static <T> CommonResponse<T> error(ResponseCode code, T data) {
-        return new CommonResponse<>(code.code(), code.message(), data, null);
+        return new CommonResponse<>(code.code(), code.message(), data);
     }
 
     public static <T> CommonResponse<T> error(String code, String message) {
-        return new CommonResponse<>(code, message, null, null);
+        return new CommonResponse<>(code, message, null);
     }
 
 //    public CommonResponse<T> withToken(String token) {

--- a/src/main/java/com/grepp/spring/infra/response/InjectJwtToBodyAdvice.java
+++ b/src/main/java/com/grepp/spring/infra/response/InjectJwtToBodyAdvice.java
@@ -1,0 +1,44 @@
+package com.grepp.spring.infra.response;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+@RestControllerAdvice
+public class InjectJwtToBodyAdvice implements ResponseBodyAdvice<CommonResponse<?>>  {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    @Override
+    public boolean supports(MethodParameter returnType,
+        Class<? extends HttpMessageConverter<?>> converterType) {
+        return returnType.getParameterType().isAssignableFrom(CommonResponse.class);
+    }
+
+    @Override
+    public CommonResponse<?> beforeBodyWrite(CommonResponse<?> body, MethodParameter returnType,
+        MediaType selectedContentType,
+        Class<? extends HttpMessageConverter<?>> selectedConverterType, ServerHttpRequest request,
+        ServerHttpResponse response) {
+        // Authorization 획득
+        String authHeader = request.getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
+
+        // JWT 있는 경우
+        if (authHeader != null && !authHeader.isBlank()) {
+            String token = authHeader;
+            // Bearer 가 있다면 제거
+            if (authHeader.startsWith(BEARER_PREFIX)) {
+                token = authHeader.substring(BEARER_PREFIX.length());
+            }
+            return body.withToken(token);
+        }
+
+        // 요청 헤더 JWT 가 없는 경우 그대로 반환
+        return body;
+    }
+}

--- a/src/main/java/com/grepp/spring/infra/response/InjectJwtToBodyAdvice.java
+++ b/src/main/java/com/grepp/spring/infra/response/InjectJwtToBodyAdvice.java
@@ -1,45 +1,45 @@
-package com.grepp.spring.infra.response;
-
-import org.springframework.core.MethodParameter;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
-import org.springframework.http.converter.HttpMessageConverter;
-import org.springframework.http.server.ServerHttpRequest;
-import org.springframework.http.server.ServerHttpResponse;
-import org.springframework.web.bind.annotation.RestControllerAdvice;
-import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
-
-@RestControllerAdvice
-public class InjectJwtToBodyAdvice implements ResponseBodyAdvice<CommonResponse<?>>  {
-
-    private static final String BEARER_PREFIX = "Bearer ";
-
-    @Override
-    public boolean supports(MethodParameter returnType,
-        Class<? extends HttpMessageConverter<?>> converterType) {
-        return returnType.getParameterType().isAssignableFrom(CommonResponse.class);
-    }
-
-    @Override
-    public CommonResponse<?> beforeBodyWrite(CommonResponse<?> body, MethodParameter returnType,
-        MediaType selectedContentType,
-        Class<? extends HttpMessageConverter<?>> selectedConverterType, ServerHttpRequest request,
-        ServerHttpResponse response) {
-        // Authorization 획득
-        String authHeader = request.getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
-
-        // JWT 있는 경우
-        if (authHeader != null && !authHeader.isBlank()) {
-            String token = authHeader;
-            // Bearer 가 있다면 제거
-            if (authHeader.startsWith(BEARER_PREFIX)) {
-                token = authHeader.substring(BEARER_PREFIX.length());
-            }
-            return body.withToken(token);
-        }
-
-        // 요청 헤더 JWT 가 없는 경우 그대로 반환
-        return body;
-    }
-
-}
+//package com.grepp.spring.infra.response;
+//
+//import org.springframework.core.MethodParameter;
+//import org.springframework.http.HttpHeaders;
+//import org.springframework.http.MediaType;
+//import org.springframework.http.converter.HttpMessageConverter;
+//import org.springframework.http.server.ServerHttpRequest;
+//import org.springframework.http.server.ServerHttpResponse;
+//import org.springframework.web.bind.annotation.RestControllerAdvice;
+//import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+//
+//@RestControllerAdvice
+//public class InjectJwtToBodyAdvice implements ResponseBodyAdvice<CommonResponse<?>>  {
+//
+//    private static final String BEARER_PREFIX = "Bearer ";
+//
+//    @Override
+//    public boolean supports(MethodParameter returnType,
+//        Class<? extends HttpMessageConverter<?>> converterType) {
+//        return returnType.getParameterType().isAssignableFrom(CommonResponse.class);
+//    }
+//
+//    @Override
+//    public CommonResponse<?> beforeBodyWrite(CommonResponse<?> body, MethodParameter returnType,
+//        MediaType selectedContentType,
+//        Class<? extends HttpMessageConverter<?>> selectedConverterType, ServerHttpRequest request,
+//        ServerHttpResponse response) {
+//        // Authorization 획득
+//        String authHeader = request.getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
+//
+//        // JWT 있는 경우
+//        if (authHeader != null && !authHeader.isBlank()) {
+//            String token = authHeader;
+//            // Bearer 가 있다면 제거
+//            if (authHeader.startsWith(BEARER_PREFIX)) {
+//                token = authHeader.substring(BEARER_PREFIX.length());
+//            }
+//            return body.withToken(token);
+//        }
+//
+//        // 요청 헤더 JWT 가 없는 경우 그대로 반환
+//        return body;
+//    }
+//
+//}

--- a/src/main/java/com/grepp/spring/infra/response/InjectJwtToBodyAdvice.java
+++ b/src/main/java/com/grepp/spring/infra/response/InjectJwtToBodyAdvice.java
@@ -41,4 +41,5 @@ public class InjectJwtToBodyAdvice implements ResponseBodyAdvice<CommonResponse<
         // 요청 헤더 JWT 가 없는 경우 그대로 반환
         return body;
     }
+
 }


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- api uri에 studyId가 있는 경우 사용가능하며 JWT claims에 저장된 memberId와 api uri에 있는 studyId를 이용해 StudyMember에 접근해 해당 스터디에서 유저의 스터디 역할을 가져와 권한을 확인합니다.
- 그리고 어노테이션에 입력된 권한이 있다면 메서드를 동작시키고 권한이 없거나 스터디맴버가 아니라면 예외를 던지도록 하였습니다.

**주의**
- 해당 어노테이션은 api uri에 studyId가 있어야합니다.
- 또한, 새로운 스레드가 만들어지는 비동기 동작(@Async, @Scheduled 같은거)에서 사용할 수 없습니다.
- 메시징큐, 웹소켓 등 Http 요청이 아닌경우 사용할 수 없습니다.

원래는 JWT에 StudyRole 넣고 동적으로 관리하고 싶었는데 구현하다 머리가 아파서 그만뒀습니다. 여유가 생기면 시도해볼 생각입니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
솔직히 대단한 이유없이 그냥 어노테이션 한번 만들고 싶어서 만들어본게 큽니다.
일단 현재 메시징큐와 웹소켓을 사용하는 채팅에서는 유저 권한 처리가 되었던 걸로 보이고 스터디 로직에서는 비동기로직에서 권한 확인을 하지 않기에 구현을 했습니다.
- 적용 예시
<img width="783" height="378" alt="Screenshot 2025-07-14 at 11 39 55 PM" src="https://github.com/user-attachments/assets/dfc7cb7d-cba0-469e-a275-ca11fd6d212c" />

예시로 출석을 해당 스터디의 맴버와 리더만 가능하도록 하였습니다.

- 권한이 있는 유저가 출석 시
<img width="1038" height="758" alt="Screenshot 2025-07-14 at 11 19 19 PM" src="https://github.com/user-attachments/assets/82713508-a2ad-4bf9-bb58-e2a0ae9a98fe" />

- 해당 스터디의 스터디원(Member, Leader)가 아닌 경우
<img width="1167" height="180" alt="스터디 역할 권한_스터디원아님" src="https://github.com/user-attachments/assets/996c8a2a-fbc3-4b85-85a8-6d9038c1a433" />
외부적으로는 4010 권한없음 메시지를 보내고 내부 로그에서 예외 원인을 확인할 수 있습니다.

- 해당 스터디원이나 권한이 없는 경우(이건 설정을 Leader로만 했을 때 Member가 요청할 때 입니다)
<img width="1167" height="180" alt="스터디역할권한_역할의 권한부족" src="https://github.com/user-attachments/assets/550492fb-d606-4d56-8b4e-ab542645478a" />

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
원래는 해보고 싶어서 구현하긴 했는데 외부에서 Repository에 접근하면 계층 분리가 깨지는 것이 아닌가 생각했는데 AOP의 관점에서 횡단 관심사라는 개념으로 보면 기존의 2차원 상의 계층이 아닌 3차원의 계층으로 확장되고 3차원 상의 계층과 연결되는 것이라 기존의 2차원 상의 계층 분리가 깨지는 것이 아니다라는 것같습니다.
- 2차원의 관점에서는 계층 분리원칙이 2차원 좌표 평면 상의 직선이 계층 간의 연결이라 했을 때 해당 직선 상에 교점이 발생하면 계층 분리가 깨진 것이라 볼 수 있는데 AOP는 2차 평면 상이 아닌 3차원 공간의 Z축으로 직선이 생기는 것이라 2차원 공간의 계층과 충돌이 없다고 본다는 느낌인 것같습니다.
- 그리고 여기서 3차원 상의 새로운 축, z축을 Aspect, 2차원 평면과 3차원 직선의 교점을 위빙이라고 하는 것같습니다.

일단 생각나는대로 써봤는데 제가 제대로 이해한 건지는 모르겠네요.
이후에 일정 상 여유가 생기면 같이 공부하면 좋을 것같습니다.

참고 사이트
- https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/context/request/RequestContextHolder.html
- https://gompangs.tistory.com/entry/Spring-RequestContextHolder
- https://www.baeldung.com/spring-aop
- https://docs.spring.io/spring-framework/reference/core/aop/introduction-defn.html
- [유튜브 우테코 AOP 영상 1](https://www.youtube.com/watch?v=Hm0w_9ngDpM)
- [ 유튜브 우테코 AOP 영상2](https://www.youtube.com/watch?v=hdO_V7EMU4s)