### PR TITLE
Feat: 인가 처리 추가 후 주석

### DIFF
--- a/src/main/java/com/grepp/spring/infra/config/security/SecurityConfig.java
+++ b/src/main/java/com/grepp/spring/infra/config/security/SecurityConfig.java
@@ -49,7 +49,11 @@ public class SecurityConfig {
             .logout(AbstractHttpConfigurer::disable)
             .authorizeHttpRequests(
                 (requests) -> requests
-                                  .anyRequest().permitAll()
+//                    .requestMatchers("/favicon.ico", "/img/**", "/js/**","/css/**").permitAll()
+//                    .requestMatchers("/", "/error", "/auth/login", "/auth/signup").permitAll()
+//                    .requestMatchers("/api/v1/studies/search").permitAll()
+//                    .anyRequest().authenticated()
+                    .anyRequest().permitAll()
             )
             // jwtAuthenticationEntryPoint 는 oauth 인증을 사용할 경우 제거
 //            .exceptionHandling(ex -> ex.authenticationEntryPoint(jwtAuthenticationEntryPoint))


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
현재 루트 페이지(/)와 스터디 목록 요청(/api/v1/studies/search)를 제외하고 로그인해야 가능하도록 설정했습니다.

+ 제 인텔리제이가 이상한 건지 spring security가 버전이 올라가면서 이전 양식 지원을 제대로 못 해주는 건지 멀쩡한 설정이 문법오류라고 표시할 때가 있는데 gradle clean하고 invalid cache하면 정상으로 돌아오더라구요.
