### PR TITLE
Feat: 멤버 정보 요구 사항 구현

### DIFF
--- a/src/main/java/com/grepp/spring/app/controller/api/member/MemberController.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/member/MemberController.java
@@ -2,12 +2,18 @@ package com.grepp.spring.app.controller.api.member;
 
 import com.grepp.spring.app.controller.api.member.payload.request.MemberUpdateRequest;
 import com.grepp.spring.app.controller.api.member.payload.request.PasswordVerifyRequest;
+import com.grepp.spring.app.model.member.dto.response.AvatarInfoResponse;
 import com.grepp.spring.app.model.member.dto.response.MemberInfoResponse;
 import com.grepp.spring.app.model.member.dto.response.MemberMyPageResponse;
 import com.grepp.spring.app.model.member.dto.response.MemberStudyListResponse;
 import com.grepp.spring.app.model.member.dto.response.PasswordVerifyResponse;
+import com.grepp.spring.app.model.member.dto.response.RequiredMemberInfoResponse;
 import com.grepp.spring.app.model.member.service.MemberService;
+import com.grepp.spring.app.model.reward.service.OwnItemService;
+import com.grepp.spring.app.model.reward.service.RewardItemService;
 import com.grepp.spring.infra.response.CommonResponse;
+import com.grepp.spring.infra.util.SecurityUtil;
+import java.util.LinkedHashMap;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -24,6 +30,8 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberController {
 
     private final MemberService memberService;
+    private final RewardItemService rewardItemService;
+    private final OwnItemService ownItemService;
 
     // 유저 정보 조회(이메일, 닉네임, 아바타)
     @GetMapping("/{memberId}/info")
@@ -72,6 +80,18 @@ public class MemberController {
         MemberMyPageResponse dto = memberService.getMyPage(memberId);
 
         return ResponseEntity.ok(CommonResponse.success(dto, "마이페이지 정보를 성공적으로 불러왔습니다."));
+    }
+
+    // 요구사항 - 맴버테이블 전체 + 입고 있는 아바타 정보
+    @GetMapping("/info-all")
+    public ResponseEntity<CommonResponse<?>> infoAll() {
+        Long memberId = SecurityUtil.getCurrentMemberId();
+        RequiredMemberInfoResponse memberInfoRes =  memberService.getMemberRequiredInfo(memberId);
+        AvatarInfoResponse avatarRes = memberService.getMemberAvatarInfo(memberId);
+        LinkedHashMap<String, Object> responseData = new LinkedHashMap<>();
+        responseData.put("memberInfo", memberInfoRes);
+        responseData.put("avatarInfo", avatarRes);
+        return ResponseEntity.ok(CommonResponse.success(responseData));
     }
 
 }

--- a/src/main/java/com/grepp/spring/app/model/member/dto/response/AvatarInfoResponse.java
+++ b/src/main/java/com/grepp/spring/app/model/member/dto/response/AvatarInfoResponse.java
@@ -1,0 +1,20 @@
+package com.grepp.spring.app.model.member.dto.response;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AvatarInfoResponse {
+
+    private String avatarImage;
+    List<Long> ItemIds;
+
+    @Builder
+    public AvatarInfoResponse(String avatarImage, List<Long> itemIds) {
+        this.avatarImage = avatarImage;
+        ItemIds = itemIds;
+    }
+}

--- a/src/main/java/com/grepp/spring/app/model/member/dto/response/RequiredMemberInfoResponse.java
+++ b/src/main/java/com/grepp/spring/app/model/member/dto/response/RequiredMemberInfoResponse.java
@@ -1,0 +1,39 @@
+package com.grepp.spring.app.model.member.dto.response;
+
+import com.grepp.spring.app.model.auth.code.Role;
+import com.grepp.spring.app.model.member.code.Gender;
+import com.grepp.spring.app.model.member.code.SocialType;
+import java.time.LocalDate;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class RequiredMemberInfoResponse {
+
+    private Long id;
+    private String email;
+    private String nickname;
+    private LocalDate birthday;
+    private Gender gender;
+    private Integer rewardPoints;
+    private Integer winCount;
+    private SocialType socialType;
+    private Role role;
+
+    @Builder
+    public RequiredMemberInfoResponse(Long id, String email, String nickname,
+        LocalDate birthday, Gender gender, Integer rewardPoints, Integer winCount,
+        SocialType socialType, Role role) {
+        this.id = id;
+        this.email = email;
+        this.nickname = nickname;
+        this.birthday = birthday;
+        this.gender = gender;
+        this.rewardPoints = rewardPoints;
+        this.winCount = winCount;
+        this.socialType = socialType;
+        this.role = role;
+    }
+}

--- a/src/main/java/com/grepp/spring/app/model/member/repository/MemberRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/member/repository/MemberRepository.java
@@ -1,9 +1,7 @@
 package com.grepp.spring.app.model.member.repository;
 
-import com.grepp.spring.app.model.member.entity.Attendance;
+import com.grepp.spring.app.model.member.dto.response.RequiredMemberInfoResponse;
 import com.grepp.spring.app.model.member.entity.Member;
-import java.time.LocalDate;
-import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -22,4 +20,11 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     @Query("SELECT m.nickname FROM Member m WHERE m.id = :id")
     String findNicknameById(@Param("id")Long Id);
 
+    @Query("select new com.grepp.spring.app.model.member.dto.response.RequiredMemberInfoResponse"
+        + "(m.id, m.email, m.nickname, m.birthday, m.gender, m.rewardPoints, m.winCount, m.socialType, m.role) "
+        + "from Member m where m.activated = true and m.id = :memberId")
+    RequiredMemberInfoResponse findRequiredMemberInfo(@Param("memberId") Long memberId);
+
+    @Query("select m.avatarImage  from Member m where m.id = :memberId")
+    String findAvatarImageById(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/grepp/spring/app/model/member/service/MemberService.java
+++ b/src/main/java/com/grepp/spring/app/model/member/service/MemberService.java
@@ -6,10 +6,12 @@ import com.grepp.spring.app.model.auth.dto.SignupRequest;
 import com.grepp.spring.app.model.auth.dto.SocialMemberInfoRegistRequest;
 import com.grepp.spring.app.model.member.code.SocialType;
 import com.grepp.spring.app.model.member.dto.response.AchievementRecordResponse;
+import com.grepp.spring.app.model.member.dto.response.AvatarInfoResponse;
 import com.grepp.spring.app.model.member.dto.response.MemberInfoResponse;
 import com.grepp.spring.app.model.member.dto.response.MemberMyPageResponse;
 import com.grepp.spring.app.model.member.dto.response.MemberStudyListResponse;
 import com.grepp.spring.app.model.member.dto.response.MypageStudyInfoResponse;
+import com.grepp.spring.app.model.member.dto.response.RequiredMemberInfoResponse;
 import com.grepp.spring.app.model.member.dto.response.StudyInfoResponse;
 import com.grepp.spring.app.model.member.entity.Attendance;
 import com.grepp.spring.app.model.member.entity.Member;
@@ -17,6 +19,7 @@ import com.grepp.spring.app.model.member.entity.StudyMember;
 import com.grepp.spring.app.model.member.repository.MemberRepository;
 import com.grepp.spring.app.model.member.repository.StudyAttendanceRepository;
 import com.grepp.spring.app.model.member.repository.StudyMemberRepository;
+import com.grepp.spring.app.model.reward.repository.OwnItemIdGetRepository;
 import com.grepp.spring.app.model.study.entity.GoalAchievement;
 import com.grepp.spring.app.model.study.entity.Study;
 import com.grepp.spring.app.model.study.entity.StudySchedule;
@@ -48,6 +51,7 @@ public class MemberService {
     private final PasswordEncoder passwordEncoder;
     private final StudyAttendanceRepository studyAttendanceRepository;
     private final GoalAchievementRepository goalAchievementRepository;
+    private final OwnItemIdGetRepository ownItemIdGetRepository;
 
     @Transactional
     public Member join(SignupRequest req) {
@@ -294,4 +298,19 @@ public class MemberService {
         );
     }
 
+    @Transactional(readOnly = true)
+    public RequiredMemberInfoResponse getMemberRequiredInfo(Long memberId) {
+        return memberRepository.findRequiredMemberInfo(memberId);
+    }
+
+    @Transactional(readOnly = true)
+    public AvatarInfoResponse getMemberAvatarInfo(Long memberId) {
+        List<Long> ids = ownItemIdGetRepository.findOwnItemIdsByMemberId(memberId);
+        String memberAvatarImage = memberRepository.findAvatarImageById(memberId);
+        AvatarInfoResponse avatarInfoResponse = AvatarInfoResponse.builder()
+            .itemIds(ids)
+            .avatarImage(memberAvatarImage)
+            .build();
+        return avatarInfoResponse;
+    }
 }

--- a/src/main/java/com/grepp/spring/app/model/reward/repository/OwnItemIdGetRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/reward/repository/OwnItemIdGetRepository.java
@@ -1,0 +1,19 @@
+package com.grepp.spring.app.model.reward.repository;
+
+
+import com.grepp.spring.app.model.reward.entity.OwnItem;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OwnItemIdGetRepository extends JpaRepository<OwnItem,Long>{
+
+    @Query("select o.rewardItem.itemId "
+        + "from OwnItem o where o.isUsed = true "
+        + "and o.rewardItem.itemType != 'BACKGROUND' and o.memberId = :memberId")
+    List<Long> findOwnItemIdsByMemberId(@Param("memberId") Long memberId);
+
+}


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
프론트분들이 요구하신 맴버 정보 + 입고 있는 아이템 id 반환을 하는 메서드를 구현하였습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
<img width="575" height="378" alt="Screenshot 2025-07-15 at 3 30 49 PM" src="https://github.com/user-attachments/assets/c1430fba-ce87-4593-8af0-ac473f620ec4" />

- 비밀번호를 제외한 맴버 정보와 해당 맴버가 활성화한 아이템 중 타입이 배경이 아닌 것들을 리스트 형태로 가져오도록 구현했습니다.
- 해당 요청은 맴버 개인이 가지는 요청이고 로그인 이후에 요청이 발생하기 때문에 jwt에서 맴버 id를 가져오는 방식으로 구현을 했고 api uri에서도 memberId를 빼버렸습니다.
- 현재 api uri 경로는 /api/v1/members/info-all입니다
