### PR TITLE
Fix: 로그아웃 필터 체인 탈출 및 index 버튼 방식 변경

### DIFF
--- a/src/main/java/com/grepp/spring/infra/auth/jwt/filter/LogoutFilter.java
+++ b/src/main/java/com/grepp/spring/infra/auth/jwt/filter/LogoutFilter.java
@@ -26,29 +26,31 @@ public class LogoutFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
         FilterChain filterChain) throws ServletException, IOException {
-        
-        String accessToken = jwtTokenProvider.resolveToken(request, AuthToken.ACCESS_TOKEN);
-        
-        if(accessToken == null){
-            filterChain.doFilter(request,response);
+
+        String path = request.getRequestURI();
+        if (!path.equals("/auth/logout")) {
+            filterChain.doFilter(request, response); // 로그아웃 요청이 아니면 다음 필터로 바로 넘깁니다.
             return;
         }
         
-        String path = request.getRequestURI();
-        Claims claims  = jwtTokenProvider.getClaims(accessToken);
-        
-        if(path.equals("/auth/logout")){
-            refreshTokenService.deleteByAccessTokenId(claims.getId());
-            SecurityContextHolder.clearContext();
-            ResponseCookie expiredAccessToken = TokenCookieFactory.createExpiredToken(AuthToken.ACCESS_TOKEN.name());
-            ResponseCookie expiredRefreshToken = TokenCookieFactory.createExpiredToken(AuthToken.REFRESH_TOKEN.name());
-            ResponseCookie expiredSessionId = TokenCookieFactory.createExpiredToken(AuthToken.AUTH_SERVER_SESSION_ID.name());
-            response.addHeader("Set-Cookie", expiredAccessToken.toString());
-            response.addHeader("Set-Cookie", expiredRefreshToken.toString());
-            response.addHeader("Set-Cookie", expiredSessionId.toString());
-            response.sendRedirect("/");
+        String accessToken = jwtTokenProvider.resolveToken(request, AuthToken.ACCESS_TOKEN);
+
+        if(accessToken == null){
+            response.setStatus(HttpServletResponse.SC_NO_CONTENT);
+            return;
         }
-        
-        filterChain.doFilter(request,response);
+
+        Claims claims  = jwtTokenProvider.getClaims(accessToken);
+
+        refreshTokenService.deleteByAccessTokenId(claims.getId());
+        SecurityContextHolder.clearContext();
+        ResponseCookie expiredAccessToken = TokenCookieFactory.createExpiredToken(AuthToken.ACCESS_TOKEN.name());
+        ResponseCookie expiredRefreshToken = TokenCookieFactory.createExpiredToken(AuthToken.REFRESH_TOKEN.name());
+        ResponseCookie expiredSessionId = TokenCookieFactory.createExpiredToken(AuthToken.AUTH_SERVER_SESSION_ID.name());
+        response.addHeader("Set-Cookie", expiredAccessToken.toString());
+        response.addHeader("Set-Cookie", expiredRefreshToken.toString());
+        response.addHeader("Set-Cookie", expiredSessionId.toString());
+        response.setStatus(HttpServletResponse.SC_OK);
+
     }
 }

--- a/src/main/resources/templates/home/index.html
+++ b/src/main/resources/templates/home/index.html
@@ -20,10 +20,42 @@
         </div>
     </div>
     <div>
-        <form th:action="@{/auth/logout}" method="post">
-            <button type="submit">로그아웃</button>
-        </form>
+        <button id="logoutBtn" type="button">로그아웃</button>
     </div>
-</div>
+
+</div> <th:block layout:fragment="script">
+    <script>
+      // 페이지 로드가 완료되면 스크립트 실행
+      document.addEventListener('DOMContentLoaded', function () {
+        const logoutButton = document.getElementById('logoutBtn');
+
+        if (logoutButton) {
+          logoutButton.addEventListener('click', function (event) {
+            // 기본 동작 방지
+            event.preventDefault();
+
+            // fetch API를 사용해 POST 방식으로 로그아웃 요청
+            fetch('/auth/logout', {
+              method: 'POST'
+            }).then(response => {
+              // 서버에서 200 OK 응답을 받으면
+              if (response.ok) {
+                // 로그아웃 성공 알림 후 홈페이지로 이동
+                alert('로그아웃 되었습니다.');
+                // window.location.href = '/'; // 홈페이지나 로그인 페이지로 이동
+              } else {
+                // 실패 처리
+                alert('로그아웃에 실패했습니다.');
+              }
+            }).catch(error => {
+              console.error('Logout error:', error);
+              alert('오류가 발생했습니다.');
+            });
+          });
+        }
+      });
+    </script>
+</th:block>
+
 </body>
 </html>


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
로그아웃 시 jwt 토큰이 없다면 204 http code를 jwt이 있다면 토큰을 지운 후 200 http code를 헤더에 넣어 반환하도록 변경했습니다.

## 문제 원인
해당 문제는 LogoutFilter 시 필터체인을 계속 돌아 결국 /auth/logout 경로의 핸들러를 찾는 걸  DispatcherServlet가 시도하고 실패해 404에러가 발생했습니다.

## 해결
return을 통해 필터를 더 돌지 않도록 하였으며 index.html에서도 form 태그로 로그아웃 요청을 하지 않고 js의 fetch api를 이용하도록 변경하였습니다.