### PR TITLE
Feat: timer 예외 처리 및 Transactional 적용

### DIFF
--- a/src/main/java/com/grepp/spring/app/controller/api/timer/TimerController.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/timer/TimerController.java
@@ -10,6 +10,7 @@ import com.grepp.spring.infra.response.SuccessCode;
 import com.grepp.spring.infra.util.SecurityUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -41,7 +42,7 @@ public class TimerController {
     @PostMapping("/{studyId}/{studyMemberId}")
     public ResponseEntity<CommonResponse<SuccessCode>> recordStudyTime(
         @PathVariable Long studyId, @PathVariable Long studyMemberId,
-        @RequestBody StudyTimeRecordRequest req
+        @Valid @RequestBody StudyTimeRecordRequest req
     ) {
        timerService.recordStudyTime(studyId, studyMemberId, req);
        return ResponseEntity.ok(CommonResponse.noContent(SuccessCode.SUCCESS));

--- a/src/main/java/com/grepp/spring/app/controller/api/timer/TimerController.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/timer/TimerController.java
@@ -39,12 +39,13 @@ public class TimerController {
         해당 요청은 성공메시지를 반환하며 `data`에 특별한 값은 없습니다.    
         """
     )
-    @PostMapping("/{studyId}/{studyMemberId}")
+    @PostMapping("/{studyId}")
     public ResponseEntity<CommonResponse<SuccessCode>> recordStudyTime(
-        @PathVariable Long studyId, @PathVariable Long studyMemberId,
+        @PathVariable Long studyId,
         @Valid @RequestBody StudyTimeRecordRequest req
     ) {
-       timerService.recordStudyTime(studyId, studyMemberId, req);
+        Long memberId = SecurityUtil.getCurrentMemberId();
+       timerService.recordStudyTime(studyId, memberId, req);
        return ResponseEntity.ok(CommonResponse.noContent(SuccessCode.SUCCESS));
     }
 

--- a/src/main/java/com/grepp/spring/app/controller/api/timer/payload/StudyTimeRecordRequest.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/timer/payload/StudyTimeRecordRequest.java
@@ -1,5 +1,7 @@
 package com.grepp.spring.app.controller.api.timer.payload;
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -7,6 +9,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class StudyTimeRecordRequest {
 
+    @NotNull(message = "공부 시간은 필수입니다.")
+    @PositiveOrZero(message = "공부 시간은 0 이상이어야 합니다.")
     int studyTime;
 
     public StudyTimeRecordRequest(int studyTime) {

--- a/src/main/java/com/grepp/spring/app/model/member/repository/StudyMemberRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/member/repository/StudyMemberRepository.java
@@ -35,4 +35,7 @@ public interface StudyMemberRepository extends JpaRepository<StudyMember, Long> 
     @Query("select sm.studyRole  from StudyMember sm "
         + "where sm.study.studyId = :studyId and sm.member.id = :memberId")
     Optional<StudyRole> findRoleByStudyAndMember(Long studyId, Long memberId);
+
+    @Query("select sm.studyMemberId from StudyMember sm where sm.member.id = :memberId and sm.study.studyId = :studyId")
+    Optional<Long> findStudyMemberIdByStudyIdWithMeberId(@Param("studyId") Long studyId, @Param("memberId") Long memberId);
 }

--- a/src/main/java/com/grepp/spring/app/model/timer/service/TimerService.java
+++ b/src/main/java/com/grepp/spring/app/model/timer/service/TimerService.java
@@ -78,7 +78,11 @@ public class TimerService {
     }
 
     @Transactional
-    public void recordStudyTime(Long studyId, Long studyMemberId, StudyTimeRecordRequest req) {
+    public void recordStudyTime(Long studyId, Long memberId, StudyTimeRecordRequest req) {
+
+        Long studyMemberId = studyMemberRepository.findStudyMemberIdByStudyIdWithMeberId(studyId, memberId)
+            .orElseThrow(() -> new NotFoundException("Study Member Not Found"));
+
         Timer timer = Timer.builder()
             .studyId(studyId)
             .studyMemberId(studyMemberId)

--- a/src/main/java/com/grepp/spring/app/model/timer/service/TimerService.java
+++ b/src/main/java/com/grepp/spring/app/model/timer/service/TimerService.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import com.querydsl.core.Tuple;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -26,6 +27,7 @@ public class TimerService {
     private final TimerQueryRepository timerQueryRepository;
     private final StudyMemberRepository studyMemberRepository;
 
+    @Transactional(readOnly = true)
     public TotalStudyTimeResponse getAllStudyTime(Long memberId) {
         List<Long> studyMemberIds = studyMemberRepository.findAllStudies(memberId);
         if (studyMemberIds == null || studyMemberIds.isEmpty()) {
@@ -43,6 +45,7 @@ public class TimerService {
             .build();
     }
 
+    @Transactional
     public List<DailyStudyLogResponse> findDailyStudyLogsByStudyMemberId(Long studyId, Long memberId) {
         Long studyMemberId = studyMemberRepository.findIdByStudyMemberIdAndMemberId(studyId, memberId)
             .orElseThrow(() -> new NotFoundException("Study Member Not Found"));
@@ -59,6 +62,7 @@ public class TimerService {
             .toList();
     }
 
+    @Transactional(readOnly = true)
     public StudyWeekTimeResponse getStudyTimeForPeriod(Long studyId, Long memberId) {
         Long studyMemberId = studyMemberRepository.findIdByStudyMemberIdAndMemberId(studyId, memberId)
             .orElseThrow(() -> new NotFoundException("Study Member Not Found"));
@@ -69,10 +73,11 @@ public class TimerService {
         Long totalTime = timerQueryRepository.findTotalStudyTimeInPeriod(studyMemberId, studyId, startOfDay, endOfDay);
 
         return StudyWeekTimeResponse.builder()
-            .totalStudyTime(totalTime)
+            .totalStudyTime(totalTime != null ? totalTime : 0L)
             .build();
     }
 
+    @Transactional
     public void recordStudyTime(Long studyId, Long studyMemberId, StudyTimeRecordRequest req) {
         Timer timer = Timer.builder()
             .studyId(studyId)

--- a/src/main/java/com/grepp/spring/infra/error/RestApiExceptionAdvice.java
+++ b/src/main/java/com/grepp/spring/infra/error/RestApiExceptionAdvice.java
@@ -7,12 +7,9 @@ import com.grepp.spring.infra.error.exceptions.InsufficientRewardPointsException
 import com.grepp.spring.infra.error.exceptions.MailSendFailureException;
 import com.grepp.spring.infra.error.exceptions.OutOfMinimumPageException;
 import com.grepp.spring.infra.error.exceptions.OutOfMinimumPageSizeException;
-import com.grepp.spring.infra.error.exceptions.RewardApiException;
 import com.grepp.spring.infra.response.CommonResponse;
 import com.grepp.spring.infra.response.ResponseCode;
 import com.grepp.spring.infra.util.NotFoundException;
-import java.util.LinkedHashMap;
-import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataAccessException;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/grepp/spring/infra/error/RestApiExceptionAdvice.java
+++ b/src/main/java/com/grepp/spring/infra/error/RestApiExceptionAdvice.java
@@ -14,6 +14,7 @@ import com.grepp.spring.infra.util.NotFoundException;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authorization.AuthorizationDeniedException;
@@ -139,6 +140,14 @@ public class RestApiExceptionAdvice {
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
             .body(CommonResponse.error(ResponseCode.BAD_REQUEST.code(), ex.getMessage()));
+    }
+
+    @ExceptionHandler(DataAccessException.class)
+    public ResponseEntity<CommonResponse<String>> handleDataAccessException(DataAccessException ex) {
+        log.error(ex.getMessage(), ex);
+        return ResponseEntity
+            .status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(CommonResponse.error(ResponseCode.INTERNAL_SERVER_ERROR));
     }
 
 }


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
API 명세서 작성하다 코드를 보는데 예외처리가 안되어 있던 것들이 있어 수정하였습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- Service에 Transactional 어노테이션이 없어 붙어넣었습니다.(아이참 누가 짠거야 하하)
- DB조회 예외도 생길 수 있을 것같아 RestApiExceptionAdvice에 추가하였습니다.
- getStudyTimeForPeriod에서 totalTime이 0일 수는 없을 것같은데 엔티티에 딱히 not null 조건이 없기에 추가하였습니다.

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
- 준형님이 말씀하신대로 Service에서 클래스단이나 메서드에 Transactional 어노테이션을 붙이고 조회의 경우 readOnly=true를 추가하였습니다.
