### PR TITLE
Chore: 소셜 로그인 리다이랙트 경로 변경 (http)

### DIFF
--- a/src/main/java/com/grepp/spring/infra/auth/oauth2/OAuth2SuccessHandler.java
+++ b/src/main/java/com/grepp/spring/infra/auth/oauth2/OAuth2SuccessHandler.java
@@ -36,7 +36,6 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     private final JwtTokenProvider jwtTokenProvider;
     private final MemberRepository memberRepository;
 
-    // fixme "여기에 추가 정보받는 페이지 경로(프론트 경로를 알아야함 아마)"
     @Value("${app.frontend.signup-redirect}")
     private String signupRedirectUrl;
 

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -59,7 +59,7 @@ springdoc.pathsToMatch=/api/**
 jwt.expiration=5184000000
 jwt.refresh-expiration=604800000
 
-front-server.domain=https://localhost:3000
+front-server.domain=http://localhost:3000
 app.frontend.signup-redirect=http://localhost:3000/signup/social
 
 # OAuth2.0

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -59,8 +59,8 @@ springdoc.pathsToMatch=/api/**
 jwt.expiration=5184000000
 jwt.refresh-expiration=604800000
 
-front-server.domain=http://localhost:3000
-app.frontend.signup-redirect=/first-oauth
+front-server.domain=https://localhost:3000
+app.frontend.signup-redirect=http://localhost:3000/signup/social
 
 # OAuth2.0
 spring.security.oauth2.client.registration.kakao.redirect-uri={baseUrl}/login/oauth2/code/{registrationId}


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
현재 백엔드 서버의 Thymeleaf 페이지로 리다리랙트 중이던 첫 소셜 로그인 시 상세 정보 입력페이지를 프론트 서버 경로로 변경하였습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
application 파일에 
app.frontend.signup-redirect=http://localhost:3000/signup/social
을 해당 url로 변경했습니다.

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
문제 없겠죠..?
