### PR TITLE
Refactor: local email로 social login 시 query param으로 해당 상태 추가

### DIFF
--- a/src/main/java/com/grepp/spring/infra/auth/oauth2/OAuth2SuccessHandler.java
+++ b/src/main/java/com/grepp/spring/infra/auth/oauth2/OAuth2SuccessHandler.java
@@ -1,6 +1,7 @@
 package com.grepp.spring.infra.auth.oauth2;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.grepp.spring.app.controller.api.auth.payload.TokenResponse;
 import com.grepp.spring.app.model.auth.AuthService;
 import com.grepp.spring.app.model.auth.code.AuthToken;
 import com.grepp.spring.app.model.auth.code.Role;
@@ -17,9 +18,11 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
@@ -120,13 +123,8 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         // 현재 같은 이메일의 로컬 계정이 존재할때 로그인 거부 및 로컬 로그인 안내
         Member member = existMember.orElseThrow(); // NPE 방지용
         if (member.getSocialType() == SocialType.LOCAL) {
-
-            CommonResponse<?> errorResponse = CommonResponse.error(ResponseCode.SOCIAL_LOGIN_CONFLICT);
-            String json = new ObjectMapper().writeValueAsString(errorResponse);
-
-            response.getWriter().write(json);
-            response.setStatus(HttpServletResponse.SC_CONFLICT); // 409
-            response.getWriter().flush();
+            String redirectUrlWithQuery = signupRedirectMainUrl + "?error=local-email";
+            getRedirectStrategy().sendRedirect(request, response, redirectUrlWithQuery);
             return;
         }
 


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
이미 로컬 이메일로 가입한 이메일로 소셜 로그인을 시도한 경우 메인페이지 주소에 query string을 추가한 뒤 리다이랙트 시키도록 변경하였습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
기존의 경우 필터단에서 강제적으로 json형태의 응답 body를 던져주니 이게 페이지 형태로 나타나 프론트분들이 처리가 할 수 없는 문제가 나타났습니다.
이를 위해 http status만 던져주려 했지만 기본 http error페이지만 나타나니 사용자 경험이 떨어질 것이라 생각했고 여기서 리다이랙트를 시키면 해당 상태를 프론트에서 받을 수 없었습니다.
그렇기에 대한 상태를 query string으로 메인 주소에 달아 보내도록 하였습니다.

<img width="516" height="436" alt="Screenshot 2025-07-21 at 5 10 03 PM" src="https://github.com/user-attachments/assets/6942e1a8-9877-4dca-948b-e622b19a96cf" />

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
더 좋은 방법있으면 알려주세요.