### PR TITLE
Refactor: info-all 아바타 사용 아이템 정보 수정

### DIFF
--- a/src/main/java/com/grepp/spring/app/model/member/service/MemberService.java
+++ b/src/main/java/com/grepp/spring/app/model/member/service/MemberService.java
@@ -310,7 +310,7 @@ public class MemberService {
 
     @Transactional(readOnly = true)
     public AvatarInfoResponse getMemberAvatarInfo(Long memberId) {
-        List<Long> ids = ownItemIdGetRepository.findOwnItemIdsByMemberId(memberId);
+        List<Long> ids = ownItemIdGetRepository.findIdsByMemberId(memberId);
         String memberAvatarImage = memberRepository.findAvatarImageById(memberId);
         AvatarInfoResponse avatarInfoResponse = AvatarInfoResponse.builder()
             .itemIds(ids)

--- a/src/main/java/com/grepp/spring/app/model/reward/repository/OwnItemIdGetRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/reward/repository/OwnItemIdGetRepository.java
@@ -13,7 +13,7 @@ public interface OwnItemIdGetRepository extends JpaRepository<OwnItem,Long>{
 
     @Query("select o.rewardItem.itemId "
         + "from OwnItem o where o.isUsed = true "
-        + "and o.rewardItem.itemType != 'BACKGROUND' and o.memberId = :memberId")
+        + "and o.rewardItem.itemType != 'BACKGROUND' and o.rewardItem.itemType != 'THEME' and o.memberId = :memberId")
     List<Long> findOwnItemIdsByMemberId(@Param("memberId") Long memberId);
 
 }

--- a/src/main/java/com/grepp/spring/app/model/reward/repository/OwnItemIdGetRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/reward/repository/OwnItemIdGetRepository.java
@@ -9,11 +9,11 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface OwnItemIdGetRepository extends JpaRepository<OwnItem,Long>{
+public interface OwnItemIdGetRepository extends JpaRepository<OwnItem,Long>, OwnItemIdGetRepositoryCustom{
 
-    @Query("select o.rewardItem.itemId "
-        + "from OwnItem o where o.isUsed = true "
-        + "and o.rewardItem.itemType != 'BACKGROUND' and o.rewardItem.itemType != 'THEME' and o.memberId = :memberId")
-    List<Long> findOwnItemIdsByMemberId(@Param("memberId") Long memberId);
+//    @Query("select o.rewardItem.itemId "
+//        + "from OwnItem o where o.isUsed = true "
+//        + "and o.rewardItem.itemType != 'BACKGROUND' and o.rewardItem.itemType != 'THEME' and o.memberId = :memberId")
+//    List<Long> findOwnItemIdsByMemberId(@Param("memberId") Long memberId);
 
 }

--- a/src/main/java/com/grepp/spring/app/model/reward/repository/OwnItemIdGetRepositoryCustom.java
+++ b/src/main/java/com/grepp/spring/app/model/reward/repository/OwnItemIdGetRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.grepp.spring.app.model.reward.repository;
+
+import java.util.List;
+
+public interface OwnItemIdGetRepositoryCustom {
+
+    List<Long> findIdsByMemberId(Long memberId);
+
+}

--- a/src/main/java/com/grepp/spring/app/model/reward/repository/OwnItemIdGetRepositoryImpl.java
+++ b/src/main/java/com/grepp/spring/app/model/reward/repository/OwnItemIdGetRepositoryImpl.java
@@ -1,0 +1,31 @@
+package com.grepp.spring.app.model.reward.repository;
+
+import com.grepp.spring.app.model.reward.code.ItemType;
+import com.grepp.spring.app.model.reward.entity.QOwnItem;
+import com.grepp.spring.app.model.reward.entity.QRewardItem;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class OwnItemIdGetRepositoryImpl implements OwnItemIdGetRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+    private static final QOwnItem ownItem = QOwnItem.ownItem;
+    private static final QRewardItem rewardItem = QRewardItem.rewardItem;
+
+    @Override
+    public List<Long> findIdsByMemberId(Long memberId) {
+        return queryFactory
+            .select(ownItem.rewardItem.itemId)
+            .from(ownItem)
+            .join(ownItem.rewardItem, rewardItem)
+            .where(
+                ownItem.isUsed.isTrue(),
+                ownItem.memberId.eq(memberId),
+                rewardItem.itemType.in(ItemType.HAT, ItemType.HAIR, ItemType.FACE, ItemType.TOP),
+                rewardItem.activated.isTrue()
+            )
+            .fetch();
+    }
+}


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- ItemType에 아타바 착용아이템이 아닌 종류 Theme가 추가되면서 info-all의 avatarInfo의 ids정보에 Theme의 id가 포함되어 출력되는 문제가 발생해 이를 해결했습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- 그래서 아예 착용 타입인 HAT, HAIR, FACE, TOP만 가져오도록 조건을 변경하였습니다.
<img width="914" height="382" alt="Screenshot 2025-07-23 at 5 31 59 PM" src="https://github.com/user-attachments/assets/947d704c-3d96-4f57-b7b9-2274574cefd8" />

- 현재 더미데이터 상황입니다.
<img width="647" height="115" alt="Screenshot 2025-07-23 at 5 33 29 PM" src="https://github.com/user-attachments/assets/45ee4d6c-e59a-41ab-abec-02a502148b61" />

- 테스트 이메일은 user1@example.com (1, 10번 아이템 착용중)
<img width="1279" height="1030" alt="Screenshot 2025-07-23 at 5 27 49 PM" src="https://github.com/user-attachments/assets/9a504308-94f2-4da7-8ddc-c33c985acfe3" />

- 10번 아이템을 soft delete 후 재시도
<img width="1279" height="1030" alt="Screenshot 2025-07-23 at 5 28 46 PM" src="https://github.com/user-attachments/assets/aeccf26d-5ed7-477f-886e-10386edc5093" />

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
- JPQL을 QueryDSL로 변경하였습니다.
- 조건에 reward-itme의 activate = true를 추가하였습니다.

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
