### PR TITLE
Refactor: study service querydsl 변경

### DIFF
--- a/src/main/java/com/grepp/spring/app/controller/api/study/StudyController.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/study/StudyController.java
@@ -20,6 +20,7 @@ import com.grepp.spring.app.model.study.dto.StudyInfoResponse;
 import com.grepp.spring.app.model.study.dto.StudyListResponse;
 import com.grepp.spring.app.model.study.dto.WeeklyAttendanceResponse;
 import com.grepp.spring.app.model.study.dto.WeeklyGoalStatusResponse;
+import com.grepp.spring.app.model.study.reponse.GoalsResponse;
 import com.grepp.spring.app.model.study.reponse.StudyNoticeResponse;
 import com.grepp.spring.app.model.study.service.ApplicantService;
 import com.grepp.spring.app.model.study.service.StudyMemberService;
@@ -64,7 +65,7 @@ public class StudyController {
     @Operation(summary = "스터디 카테고리 및 상태 목록 조회",
         description = "스터디 생성 및 검색에 사용되는 카테고리(Enum)와 상태(Enum)의 전체 목록을 문자열 리스트로 조회합니다.")
     @GetMapping("/categories")
-    public ResponseEntity<?> getCategories() {
+    public ResponseEntity<CommonResponse<Map<String, Object>>> getCategories() {
         Map<String, Object> data = Map.of(
             "categories", Arrays.stream(Category.values()).map(Enum::name).toList(),
             "statuses", Arrays.stream(Status.values()).map(Enum::name).toList()
@@ -78,7 +79,7 @@ public class StudyController {
         - 이 API는 인증이 필요하며, 요청 헤더에 유효한 토큰이 있어야 합니다.
         """)
     @PostMapping("/{studyId}/attendance")
-    public ResponseEntity<?> attendance(
+    public ResponseEntity<CommonResponse<String>> attendance(
         @PathVariable Long studyId,
         Authentication authentication
     ) {
@@ -99,7 +100,7 @@ public class StudyController {
         - 이 API는 인증이 필요하며, 요청 헤더에 유효한 토큰이 있어야 합니다.
         """)
     @GetMapping("/{studyId}/attendance")
-    public ResponseEntity<?> weeklyAttendance(
+    public ResponseEntity<CommonResponse<WeeklyAttendanceResponse>> weeklyAttendance(
         @PathVariable Long studyId,
         Authentication authentication
     ) {
@@ -129,7 +130,7 @@ public class StudyController {
     // 스터디 정보 조회
     @Operation(summary = "스터디 상세 정보 조회", description = "스터디 ID(`studyId`)를 이용하여 스터디의 상세 정보를 조회합니다.")
     @GetMapping("/{studyId}")
-    public ResponseEntity<?> getStudyInfo(@PathVariable Long studyId) {
+    public ResponseEntity<CommonResponse<StudyInfoResponse>> getStudyInfo(@PathVariable Long studyId) {
         StudyInfoResponse data = studyService.getStudyInfo(studyId);
         return ResponseEntity.ok(CommonResponse.success(data));
     }
@@ -140,7 +141,7 @@ public class StudyController {
         - 스터디 ID(`studyId`)에 해당하는 스터디의 정보를 수정합니다. 스터디장만 호출 가능합니다.
         """)
     @PutMapping("/{studyId}")
-    public ResponseEntity<?> updateStudyInfo(
+    public ResponseEntity<CommonResponse<Void>> updateStudyInfo(
         @PathVariable Long studyId,
         @RequestBody StudyUpdateRequest data
     ) {
@@ -163,7 +164,7 @@ public class StudyController {
         - 이 API는 인증이 필요하며, 요청 헤더에 유효한 토큰이 있어야 합니다.
         """)
     @PostMapping("/{studyId}/application")
-    public ResponseEntity<?> application(
+    public ResponseEntity<CommonResponse<String>> application(
         @PathVariable Long studyId,
         @RequestBody ApplicationRequest req
     ) {
@@ -179,7 +180,7 @@ public class StudyController {
         - 이 API는 인증이 필요하며, 요청 헤더에 유효한 토큰이 있어야 합니다.
         """)
     @GetMapping("/{studyId}/members/me/check")
-    public ResponseEntity<?> isMember(@PathVariable Long studyId) {
+    public ResponseEntity<CommonResponse<Map<String, Boolean>>> isMember(@PathVariable Long studyId) {
         Long memberId = SecurityUtil.getCurrentMemberId();
 
         boolean isMember = studyService.isUserStudyMember(memberId, studyId);
@@ -194,7 +195,7 @@ public class StudyController {
     // 스터디 맴버 리스트 조회
     @Operation(summary = "스터디 멤버 목록 조회", description = "스터디 ID(`studyId`)에 해당하는 스터디에 속한 모든 멤버의 목록을 조회합니다.")
     @GetMapping("/{studyId}/members")
-    public ResponseEntity<?> getMembers(@PathVariable Long studyId) {
+    public ResponseEntity<CommonResponse<List<StudyMemberResponse>>> getMembers(@PathVariable Long studyId) {
         List<StudyMemberResponse> members = studyService.getStudyMembers(studyId);
         return ResponseEntity.ok(CommonResponse.success(members));
     }
@@ -219,7 +220,7 @@ public class StudyController {
     // 스터디 목표 조회
     @Operation(summary = "스터디 목표 목록 조회", description = "스터디 ID(`studyId`)에 설정된 목표 목록을 조회합니다.")
     @GetMapping("/{studyId}/goals")
-    public ResponseEntity<?> getGoals(@PathVariable Long studyId) {
+    public ResponseEntity<CommonResponse<List<GoalsResponse>>> getGoals(@PathVariable Long studyId) {
         return ResponseEntity.status(200).body(CommonResponse.success(studyService.findGoals(studyId)));
     }
 
@@ -229,7 +230,7 @@ public class StudyController {
         - 이 API는 인증이 필요하며, 요청 헤더에 유효한 토큰이 있어야 합니다.
         """)
     @PostMapping("{studyId}/goal/{goalId}")
-    public ResponseEntity<?> successGoal(@PathVariable Long studyId, @PathVariable Long goalId) {
+    public ResponseEntity<CommonResponse<Void>> successGoal(@PathVariable Long studyId, @PathVariable Long goalId) {
         Long memberId = SecurityUtil.getCurrentMemberId();
         log.info("memberId: {}", memberId);
         studyService.registGoal(List.of(studyId, memberId, goalId));
@@ -242,7 +243,7 @@ public class StudyController {
         - 이 API는 인증이 필요하며, 요청 헤더에 유효한 토큰이 있어야 합니다.
         """)
     @GetMapping("/{studyId}/goals/completed")
-    public ResponseEntity<?> getWeeklyGoalStats(
+    public ResponseEntity<CommonResponse<WeeklyGoalStatusResponse>> getWeeklyGoalStats(
         @PathVariable Long studyId) {
 
         Long memberId = SecurityUtil.getCurrentMemberId(); // 로그인된 사용자
@@ -265,7 +266,7 @@ public class StudyController {
         """
     )
     @PostMapping("/{studyId}/applications/respond")
-    public ResponseEntity<CommonResponse<?>> responseStudyApplication(
+    public ResponseEntity<CommonResponse<Void>> responseStudyApplication(
         @PathVariable Long studyId,
         @RequestBody ApplicationResultRequest req) {
 
@@ -309,7 +310,7 @@ public class StudyController {
     @Operation(summary = "스터디 공지사항 조회",
         description = "특정 스터디(`studyId`)의 공지사항을 조회합니다.")
     @GetMapping("/{studyId}/notification")
-    public ResponseEntity<CommonResponse<?>> getStudyNotification(
+    public ResponseEntity<CommonResponse<StudyNoticeResponse>> getStudyNotification(
         @PathVariable Long studyId
     ) {
         StudyNoticeResponse res = new StudyNoticeResponse(studyService.findNotice(studyId));
@@ -323,7 +324,7 @@ public class StudyController {
         - 이 API는 인증이 필요하며, 요청 헤더에 유효한 토큰이 있어야 합니다.
         """)
     @GetMapping("/{studyId}/check-goal")
-    public ResponseEntity<CommonResponse<?>> getCheckGoal(
+    public ResponseEntity<CommonResponse<List<CheckGoalResponse>>> getCheckGoal(
         @PathVariable Long studyId
     ){
         Long memberId = SecurityUtil.getCurrentMemberId();

--- a/src/main/java/com/grepp/spring/app/controller/api/study/StudyController.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/study/StudyController.java
@@ -20,7 +20,6 @@ import com.grepp.spring.app.model.study.dto.StudyInfoResponse;
 import com.grepp.spring.app.model.study.dto.StudyListResponse;
 import com.grepp.spring.app.model.study.dto.WeeklyAttendanceResponse;
 import com.grepp.spring.app.model.study.dto.WeeklyGoalStatusResponse;
-import com.grepp.spring.app.model.study.entity.Study;
 import com.grepp.spring.app.model.study.reponse.StudyNoticeResponse;
 import com.grepp.spring.app.model.study.service.ApplicantService;
 import com.grepp.spring.app.model.study.service.StudyMemberService;

--- a/src/main/java/com/grepp/spring/app/model/member/repository/StudyMemberRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/member/repository/StudyMemberRepository.java
@@ -1,24 +1,23 @@
 package com.grepp.spring.app.model.member.repository;
 
-import com.grepp.spring.app.model.member.code.StudyRole;
 import com.grepp.spring.app.model.member.entity.StudyMember;
-import org.springframework.data.repository.query.Param;
+import com.grepp.spring.app.model.study.repository.StudyMemberRepositoryCustom;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface StudyMemberRepository extends JpaRepository<StudyMember, Long> {
+public interface StudyMemberRepository extends JpaRepository<StudyMember, Long>,
+    StudyMemberRepositoryCustom {
 
     List<StudyMember> findByMemberId(Long memberId);
 
-    @Query("select sm.studyMemberId from StudyMember sm where sm.member.id = :memberId")
-    List<Long> findAllStudies(@Param("memberId") Long memberId);
+//    @Query("select sm.studyMemberId from StudyMember sm where sm.member.id = :memberId")
+//    List<Long> findAllStudies(@Param("memberId") Long memberId);
 
-    @Query("select sm.studyMemberId from StudyMember sm where sm.study.studyId = :studyId and sm.member.id = :memberId")
-    Optional<Long> findIdByStudyMemberIdAndMemberId(@Param("studyId")Long studyId, @Param("memberId") Long memberId);
+//    @Query("select sm.studyMemberId from StudyMember sm where sm.study.studyId = :studyId and sm.member.id = :memberId")
+//    Optional<Long> findIdByStudyMemberIdAndMemberId(@Param("studyId")Long studyId, @Param("memberId") Long memberId);
 
     Optional<StudyMember> findByStudyStudyIdAndMemberId(Long studyId, Long memberId);
 
@@ -28,22 +27,22 @@ public interface StudyMemberRepository extends JpaRepository<StudyMember, Long> 
 
     boolean existsByMember_IdAndStudy_StudyId(Long memberId, Long studyId);
 
-    @Query("SELECT sm FROM StudyMember sm JOIN FETCH sm.member WHERE sm.study.studyId = :studyId")
-    List<StudyMember> findAllByStudyIdWithMember(@Param("studyId") Long studyId);
+//    @Query("SELECT sm FROM StudyMember sm JOIN FETCH sm.member WHERE sm.study.studyId = :studyId")
+//    List<StudyMember> findAllByStudyIdWithMember(@Param("studyId") Long studyId);
 
 
-    @Query("select sm.studyRole  from StudyMember sm "
-        + "where sm.study.studyId = :studyId and sm.member.id = :memberId")
-    Optional<StudyRole> findRoleByStudyAndMember(@Param("studyId") Long studyId, @Param("memberId") Long memberId);
+//    @Query("select sm.studyRole  from StudyMember sm "
+//        + "where sm.study.studyId = :studyId and sm.member.id = :memberId")
+//    Optional<StudyRole> findRoleByStudyAndMember(@Param("studyId") Long studyId, @Param("memberId") Long memberId);
 
 
-    @Query("select sm.studyMemberId from StudyMember sm where sm.member.id = :memberId and sm.study.studyId = :studyId")
-    Optional<Long> findStudyMemberIdByStudyIdWithMeberId(@Param("studyId") Long studyId, @Param("memberId") Long memberId);
+//    @Query("select sm.studyMemberId from StudyMember sm where sm.member.id = :memberId and sm.study.studyId = :studyId")
+//    Optional<Long> findStudyMemberIdByStudyIdWithMeberId(@Param("studyId") Long studyId, @Param("memberId") Long memberId);
 
 
-    @Query("select sm.studyRole = com.grepp.spring.app.model.member.code.StudyRole.LEADER "
-        + "from StudyMember sm where sm.study.studyId = :studyId and sm.member.id = :acceptorId")
-    Boolean isAcceptorHasRight(@Param("acceptorId") Long acceptorId, @Param("studyId") Long studyId);
+//    @Query("select sm.studyRole = com.grepp.spring.app.model.member.code.StudyRole.LEADER "
+//        + "from StudyMember sm where sm.study.studyId = :studyId and sm.member.id = :acceptorId")
+//    Boolean isAcceptorHasRight(@Param("acceptorId") Long acceptorId, @Param("studyId") Long studyId);
 
     Optional<StudyMember> findByStudy_StudyIdAndStudyMemberId(Long studyId, Long studyMemberId);
 }

--- a/src/main/java/com/grepp/spring/app/model/member/repository/StudyMemberRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/member/repository/StudyMemberRepository.java
@@ -13,12 +13,6 @@ public interface StudyMemberRepository extends JpaRepository<StudyMember, Long>,
 
     List<StudyMember> findByMemberId(Long memberId);
 
-//    @Query("select sm.studyMemberId from StudyMember sm where sm.member.id = :memberId")
-//    List<Long> findAllStudies(@Param("memberId") Long memberId);
-
-//    @Query("select sm.studyMemberId from StudyMember sm where sm.study.studyId = :studyId and sm.member.id = :memberId")
-//    Optional<Long> findIdByStudyMemberIdAndMemberId(@Param("studyId")Long studyId, @Param("memberId") Long memberId);
-
     Optional<StudyMember> findByStudyStudyIdAndMemberId(Long studyId, Long memberId);
 
     Optional<StudyMember> findByMember_IdAndStudy_StudyId(Long memberId, Long studyId);
@@ -26,23 +20,6 @@ public interface StudyMemberRepository extends JpaRepository<StudyMember, Long>,
     int countByStudy_StudyId(Long studyId);
 
     boolean existsByMember_IdAndStudy_StudyId(Long memberId, Long studyId);
-
-//    @Query("SELECT sm FROM StudyMember sm JOIN FETCH sm.member WHERE sm.study.studyId = :studyId")
-//    List<StudyMember> findAllByStudyIdWithMember(@Param("studyId") Long studyId);
-
-
-//    @Query("select sm.studyRole  from StudyMember sm "
-//        + "where sm.study.studyId = :studyId and sm.member.id = :memberId")
-//    Optional<StudyRole> findRoleByStudyAndMember(@Param("studyId") Long studyId, @Param("memberId") Long memberId);
-
-
-//    @Query("select sm.studyMemberId from StudyMember sm where sm.member.id = :memberId and sm.study.studyId = :studyId")
-//    Optional<Long> findStudyMemberIdByStudyIdWithMeberId(@Param("studyId") Long studyId, @Param("memberId") Long memberId);
-
-
-//    @Query("select sm.studyRole = com.grepp.spring.app.model.member.code.StudyRole.LEADER "
-//        + "from StudyMember sm where sm.study.studyId = :studyId and sm.member.id = :acceptorId")
-//    Boolean isAcceptorHasRight(@Param("acceptorId") Long acceptorId, @Param("studyId") Long studyId);
 
     Optional<StudyMember> findByStudy_StudyIdAndStudyMemberId(Long studyId, Long studyMemberId);
 }

--- a/src/main/java/com/grepp/spring/app/model/study/repository/GoalAchievementRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/study/repository/GoalAchievementRepository.java
@@ -2,32 +2,32 @@ package com.grepp.spring.app.model.study.repository;
 
 import com.grepp.spring.app.model.member.entity.StudyMember;
 import com.grepp.spring.app.model.study.entity.GoalAchievement;
-import io.lettuce.core.dynamic.annotation.Param;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface GoalAchievementRepository extends JpaRepository<GoalAchievement, Long>,
     GoalRepositoryCustom {
 
-//    @Query("""
-//SELECT COUNT(DISTINCT ga.achievementId)
-//FROM GoalAchievement ga
-//JOIN ga.studyGoal sg
-//WHERE sg.study.studyId = :studyId
-//  AND ga.studyMember.studyMemberId = :studyMemberId
-//  AND ga.achievedAt BETWEEN :startDateTime AND :endDateTime
-//  AND ga.isAccomplished = true
-//""")
-//    int countTotalAchievements(
-//        @Param("studyId") Long studyId,
-//        @Param("studyMemberId") Long studyMemberId,
-//        @Param("startDateTime") LocalDateTime startDateTime,
-//        @Param("endDateTime") LocalDateTime endDateTime
-//    );
+    @Query("""
+SELECT COUNT(DISTINCT ga.achievementId)
+FROM GoalAchievement ga
+JOIN ga.studyGoal sg
+WHERE sg.study.studyId = :studyId
+  AND ga.studyMember.studyMemberId = :studyMemberId
+  AND ga.achievedAt BETWEEN :startDateTime AND :endDateTime
+  AND ga.isAccomplished = true
+""")
+    int countTotalAchievements(
+        @Param("studyId") Long studyId,
+        @Param("studyMemberId") Long studyMemberId,
+        @Param("startDateTime") LocalDateTime startDateTime,
+        @Param("endDateTime") LocalDateTime endDateTime
+    );
 
     List<GoalAchievement> findAllByStudyMemberAndIsAccomplishedTrue(StudyMember studyMember);
 

--- a/src/main/java/com/grepp/spring/app/model/study/repository/GoalAchievementRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/study/repository/GoalAchievementRepository.java
@@ -11,33 +11,24 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface GoalAchievementRepository extends JpaRepository<GoalAchievement, Long>,
-    GoalCustomRepository {
+    GoalRepositoryCustom {
 
-    @Query("""
-SELECT COUNT(DISTINCT ga.achievementId)
-FROM GoalAchievement ga
-JOIN ga.studyGoal sg
-WHERE sg.study.studyId = :studyId
-  AND ga.studyMember.studyMemberId = :studyMemberId
-  AND ga.achievedAt BETWEEN :startDateTime AND :endDateTime
-  AND ga.isAccomplished = true
-""")
-    int countTotalAchievements(
-        @Param("studyId") Long studyId,
-        @Param("studyMemberId") Long studyMemberId,
-        @Param("startDateTime") LocalDateTime startDateTime,
-        @Param("endDateTime") LocalDateTime endDateTime
-    );
+//    @Query("""
+//SELECT COUNT(DISTINCT ga.achievementId)
+//FROM GoalAchievement ga
+//JOIN ga.studyGoal sg
+//WHERE sg.study.studyId = :studyId
+//  AND ga.studyMember.studyMemberId = :studyMemberId
+//  AND ga.achievedAt BETWEEN :startDateTime AND :endDateTime
+//  AND ga.isAccomplished = true
+//""")
+//    int countTotalAchievements(
+//        @Param("studyId") Long studyId,
+//        @Param("studyMemberId") Long studyMemberId,
+//        @Param("startDateTime") LocalDateTime startDateTime,
+//        @Param("endDateTime") LocalDateTime endDateTime
+//    );
 
     List<GoalAchievement> findAllByStudyMemberAndIsAccomplishedTrue(StudyMember studyMember);
 
-//    @Query("select new com.grepp.spring.app.controller.api.study.payload.CheckGoalResponse("
-//        + "sg.goalId, sg.content, COALESCE(ga.isAccomplished, FALSE)) "
-//        + "from StudyGoal sg "
-//        + "left join GoalAchievement ga on sg.goalId = ga.studyGoal.goalId "
-//        + "and ga.studyMember.studyMemberId = :studyMemberId "
-//        + "and ga.activated = TRUE "
-//        + "where sg.study.studyId = :studyId "
-//        + "and sg.activated = TRUE")
-//    List<CheckGoalResponse> findAchieveStatusesByStudyId(@Param("studyId") Long studyId, @Param("studyMemberId") Long studyMemberId);
 }

--- a/src/main/java/com/grepp/spring/app/model/study/repository/GoalCustomRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/study/repository/GoalCustomRepository.java
@@ -1,9 +1,0 @@
-package com.grepp.spring.app.model.study.repository;
-
-import com.grepp.spring.app.controller.api.study.payload.CheckGoalResponse;
-import java.util.List;
-
-public interface GoalCustomRepository {
-    List<CheckGoalResponse> findAchieveStatusesByStudyId(Long studyId,Long studyMemberId);
-
-}

--- a/src/main/java/com/grepp/spring/app/model/study/repository/GoalRepositoryCustom.java
+++ b/src/main/java/com/grepp/spring/app/model/study/repository/GoalRepositoryCustom.java
@@ -1,0 +1,17 @@
+package com.grepp.spring.app.model.study.repository;
+
+import com.grepp.spring.app.controller.api.study.payload.CheckGoalResponse;
+import com.grepp.spring.app.model.member.entity.StudyMember;
+import com.grepp.spring.app.model.study.entity.GoalAchievement;
+import com.grepp.spring.app.model.study.reponse.GoalsResponse;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface GoalRepositoryCustom {
+    List<CheckGoalResponse> findAchieveStatusesByStudyId(Long studyId,Long studyMemberId);
+
+    List<GoalsResponse> findGoalsById(Long studyId);
+
+    int countTotalAchievements(Long studyId, Long studyMemberId, LocalDateTime startDateTime, LocalDateTime endDateTime);
+
+}

--- a/src/main/java/com/grepp/spring/app/model/study/repository/GoalRepositoryCustom.java
+++ b/src/main/java/com/grepp/spring/app/model/study/repository/GoalRepositoryCustom.java
@@ -1,17 +1,14 @@
 package com.grepp.spring.app.model.study.repository;
 
 import com.grepp.spring.app.controller.api.study.payload.CheckGoalResponse;
-import com.grepp.spring.app.model.member.entity.StudyMember;
-import com.grepp.spring.app.model.study.entity.GoalAchievement;
 import com.grepp.spring.app.model.study.reponse.GoalsResponse;
-import java.time.LocalDateTime;
 import java.util.List;
 
 public interface GoalRepositoryCustom {
-    List<CheckGoalResponse> findAchieveStatusesByStudyId(Long studyId,Long studyMemberId);
+    List<CheckGoalResponse> findAchieveStatuses(Long studyId, Long studyMemberId);
 
     List<GoalsResponse> findGoalsById(Long studyId);
 
-    int countTotalAchievements(Long studyId, Long studyMemberId, LocalDateTime startDateTime, LocalDateTime endDateTime);
+//    int getTotalAchievementsCount(Long studyId, Long studyMemberId, LocalDateTime startDateTime, LocalDateTime endDateTime);
 
 }

--- a/src/main/java/com/grepp/spring/app/model/study/repository/GoalRepositoryCustom.java
+++ b/src/main/java/com/grepp/spring/app/model/study/repository/GoalRepositoryCustom.java
@@ -7,7 +7,7 @@ import java.util.List;
 public interface GoalRepositoryCustom {
     List<CheckGoalResponse> findAchieveStatuses(Long studyId, Long studyMemberId);
 
-    List<GoalsResponse> findGoalsById(Long studyId);
+    List<GoalsResponse> findStudyGoals(Long studyId);
 
 //    int getTotalAchievementsCount(Long studyId, Long studyMemberId, LocalDateTime startDateTime, LocalDateTime endDateTime);
 

--- a/src/main/java/com/grepp/spring/app/model/study/repository/GoalRepositoryCustomImpl.java
+++ b/src/main/java/com/grepp/spring/app/model/study/repository/GoalRepositoryCustomImpl.java
@@ -8,14 +8,11 @@ import com.grepp.spring.app.model.study.reponse.GoalsResponse;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 
-import static com.grepp.spring.app.model.study.entity.QStudy.study;
-
 @RequiredArgsConstructor
-public class GoalRepositoryImpl implements GoalRepositoryCustom {
+public class GoalRepositoryCustomImpl implements GoalRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
 
@@ -26,7 +23,7 @@ public class GoalRepositoryImpl implements GoalRepositoryCustom {
 
 
     @Override
-    public List<CheckGoalResponse> findAchieveStatusesByStudyId(Long studyId, Long studyMemberId) {
+    public List<CheckGoalResponse> findAchieveStatuses(Long studyId, Long studyMemberId) {
         return queryFactory
             .select(
                 Projections.constructor(CheckGoalResponse.class,
@@ -38,13 +35,13 @@ public class GoalRepositoryImpl implements GoalRepositoryCustom {
             .from(studyGoal)
             .leftJoin(goalAchievement)
                 .on(
-                    studyGoal.goalId.eq(goalAchievement.studyGoal.goalId)
-                        .and(goalAchievement.studyMember.studyMemberId.eq(studyMemberId))
-                        .and(goalAchievement.activated.isTrue())
+                    studyGoal.goalId.eq(goalAchievement.studyGoal.goalId),
+                    goalAchievement.studyMember.studyMemberId.eq(studyMemberId),
+                    goalAchievement.activated.isTrue()
                 )
             .where(
-                studyGoal.study.studyId.eq(studyId)
-                    .and(studyGoal.activated.isTrue())
+                studyGoal.study.studyId.eq(studyId),
+                studyGoal.activated.isTrue()
             )
             .fetch();
     }
@@ -60,29 +57,30 @@ public class GoalRepositoryImpl implements GoalRepositoryCustom {
             )
             .from(studyGoal)
             .where(
-                studyGoal.study.studyId.eq(studyId).and(studyGoal.activated.isTrue())
+                studyGoal.study.studyId.eq(studyId),
+                studyGoal.activated.isTrue()
             )
             .fetch();
     }
 
-    @Override
-    public int countTotalAchievements(Long studyId, Long studyMemberId, LocalDateTime startDateTime,
-        LocalDateTime endDateTime) {
-        Long count = queryFactory
-            .select(goalAchievement.achievementId.countDistinct())
-            .from(goalAchievement)
-            .join(goalAchievement.studyGoal, studyGoal)
-            .join(studyGoal.study, study)
-            .where(
-                study.studyId.eq(studyId),
-                goalAchievement.studyMember.studyMemberId.eq(studyMemberId),
-                goalAchievement.achievedAt.between(startDateTime, endDateTime),
-                goalAchievement.isAccomplished.isTrue()
-            )
-            .fetchOne();
-
-        return count != null ? count.intValue() : 0;
-    }
+//    @Override
+//    public int getTotalAchievementsCount(Long studyId, Long studyMemberId, LocalDateTime startDateTime,
+//        LocalDateTime endDateTime) {
+//        Long count = queryFactory
+//            .select(goalAchievement.achievementId.countDistinct())
+//            .from(goalAchievement)
+//            .join(goalAchievement.studyGoal, studyGoal)
+//            .join(studyGoal.study, study)
+//            .where(
+//                study.studyId.eq(studyId),
+//                goalAchievement.studyMember.studyMemberId.eq(studyMemberId),
+//                goalAchievement.achievedAt.between(startDateTime, endDateTime),
+//                goalAchievement.isAccomplished.isTrue()
+//            )
+//            .fetchOne();
+//
+//        return count != null ? count.intValue() : 0;
+//    }
 
 
 }

--- a/src/main/java/com/grepp/spring/app/model/study/repository/GoalRepositoryCustomImpl.java
+++ b/src/main/java/com/grepp/spring/app/model/study/repository/GoalRepositoryCustomImpl.java
@@ -47,7 +47,7 @@ public class GoalRepositoryCustomImpl implements GoalRepositoryCustom {
     }
 
     @Override
-    public List<GoalsResponse> findGoalsById(Long studyId) {
+    public List<GoalsResponse> findStudyGoals(Long studyId) {
         return queryFactory
             .select(
                 Projections.constructor(GoalsResponse.class,

--- a/src/main/java/com/grepp/spring/app/model/study/repository/StudyGoalRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/study/repository/StudyGoalRepository.java
@@ -1,7 +1,6 @@
 package com.grepp.spring.app.model.study.repository;
 
 import com.grepp.spring.app.model.study.entity.StudyGoal;
-import com.grepp.spring.app.model.study.reponse.GoalsResponse;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -9,10 +8,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface StudyGoalRepository extends JpaRepository<StudyGoal, Long> {
-
-    @Query("select new com.grepp.spring.app.model.study.reponse.GoalsResponse(sg.goalId, sg.content) from StudyGoal sg WHERE sg.study.studyId = :studyId")
-    List<GoalsResponse> findGoalsById(Long studyId);
+public interface StudyGoalRepository extends JpaRepository<StudyGoal, Long>, GoalRepositoryCustom {
 
     @Query("SELECT g FROM StudyGoal g WHERE g.study.studyId = :studyId ORDER BY g.goalId ASC")
     List<StudyGoal> findGoalsByStudyId(@Param("studyId") Long studyId);

--- a/src/main/java/com/grepp/spring/app/model/study/repository/StudyMemberRepositoryCustom.java
+++ b/src/main/java/com/grepp/spring/app/model/study/repository/StudyMemberRepositoryCustom.java
@@ -1,0 +1,23 @@
+package com.grepp.spring.app.model.study.repository;
+
+import com.grepp.spring.app.model.member.code.StudyRole;
+import com.grepp.spring.app.model.member.entity.StudyMember;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.repository.query.Param;
+
+public interface StudyMemberRepositoryCustom {
+
+    List<Long> findAllStudies(@Param("memberId") Long memberId);
+
+    Optional<Long> findIdByStudyMemberIdAndMemberId(Long studyId,Long memberId);
+
+    List<StudyMember> findAllByStudyIdWithMember(Long studyId);
+
+    Optional<StudyRole> findRoleByStudyAndMember(Long studyId, Long memberId);
+
+    Optional<Long> findStudyMemberIdByStudyIdWithMeberId(Long studyId, Long memberId);
+
+    Boolean isAcceptorHasRight(@Param("acceptorId") Long acceptorId, Long studyId);
+
+}

--- a/src/main/java/com/grepp/spring/app/model/study/repository/StudyMemberRepositoryCustom.java
+++ b/src/main/java/com/grepp/spring/app/model/study/repository/StudyMemberRepositoryCustom.java
@@ -4,11 +4,10 @@ import com.grepp.spring.app.model.member.code.StudyRole;
 import com.grepp.spring.app.model.member.entity.StudyMember;
 import java.util.List;
 import java.util.Optional;
-import org.springframework.data.repository.query.Param;
 
 public interface StudyMemberRepositoryCustom {
 
-    List<Long> findAllStudies(@Param("memberId") Long memberId);
+    List<Long> findAllStudies(Long memberId);
 
     Optional<Long> findIdByStudyMemberIdAndMemberId(Long studyId,Long memberId);
 
@@ -16,8 +15,8 @@ public interface StudyMemberRepositoryCustom {
 
     Optional<StudyRole> findRoleByStudyAndMember(Long studyId, Long memberId);
 
-    Optional<Long> findStudyMemberIdByStudyIdWithMeberId(Long studyId, Long memberId);
+    Optional<Long> findStudyMemberIdByStudyIdWithMemberId(Long studyId, Long memberId);
 
-    Boolean isAcceptorHasRight(@Param("acceptorId") Long acceptorId, Long studyId);
+    Boolean checkAcceptorHasRight(Long acceptorId, Long studyId);
 
 }

--- a/src/main/java/com/grepp/spring/app/model/study/repository/StudyMemberRepositoryCustom.java
+++ b/src/main/java/com/grepp/spring/app/model/study/repository/StudyMemberRepositoryCustom.java
@@ -9,13 +9,11 @@ public interface StudyMemberRepositoryCustom {
 
     List<Long> findAllStudies(Long memberId);
 
-    Optional<Long> findIdByStudyMemberIdAndMemberId(Long studyId,Long memberId);
+    List<StudyMember> findByStudyId(Long studyId);
 
-    List<StudyMember> findAllByStudyIdWithMember(Long studyId);
+    Optional<StudyRole> findStudyRole(Long studyId, Long memberId);
 
-    Optional<StudyRole> findRoleByStudyAndMember(Long studyId, Long memberId);
-
-    Optional<Long> findStudyMemberIdByStudyIdWithMemberId(Long studyId, Long memberId);
+    Optional<Long> findStudyMemberId(Long studyId, Long memberId);
 
     Boolean checkAcceptorHasRight(Long acceptorId, Long studyId);
 

--- a/src/main/java/com/grepp/spring/app/model/study/repository/StudyMemberRepositoryCustomImpl.java
+++ b/src/main/java/com/grepp/spring/app/model/study/repository/StudyMemberRepositoryCustomImpl.java
@@ -32,7 +32,7 @@ public class StudyMemberRepositoryCustomImpl implements StudyMemberRepositoryCus
     }
 
     @Override
-    public Optional<Long> findIdByStudyMemberIdAndMemberId(Long studyId, Long memberId) {
+    public Optional<Long> findStudyMemberId(Long studyId, Long memberId) {
         Long id =  queryFactory
             .select(studyMember.studyMemberId)
             .from(studyMember)
@@ -46,7 +46,7 @@ public class StudyMemberRepositoryCustomImpl implements StudyMemberRepositoryCus
     }
 
     @Override
-    public List<StudyMember> findAllByStudyIdWithMember(Long studyId) {
+    public List<StudyMember> findByStudyId(Long studyId) {
         return queryFactory
             .selectFrom(studyMember)
             .join(studyMember.member, member).fetchJoin()
@@ -58,7 +58,7 @@ public class StudyMemberRepositoryCustomImpl implements StudyMemberRepositoryCus
     }
 
     @Override
-    public Optional<StudyRole> findRoleByStudyAndMember(Long studyId, Long memberId) {
+    public Optional<StudyRole> findStudyRole(Long studyId, Long memberId) {
         StudyRole res = queryFactory
             .select(studyMember.studyRole)
             .from(studyMember)
@@ -69,20 +69,6 @@ public class StudyMemberRepositoryCustomImpl implements StudyMemberRepositoryCus
             )
             .fetchOne();
         return Optional.ofNullable(res);
-    }
-
-    @Override
-    public Optional<Long> findStudyMemberIdByStudyIdWithMemberId(Long studyId, Long memberId) {
-        Long smId = queryFactory
-            .select(studyMember.studyMemberId)
-            .from(studyMember)
-            .where(
-                studyMember.member.id.eq(memberId),
-                studyMember.study.studyId.eq(studyId),
-                studyMember.activated.isTrue()
-            )
-            .fetchOne();
-        return Optional.ofNullable(smId);
     }
 
     @Override

--- a/src/main/java/com/grepp/spring/app/model/study/repository/StudyMemberRepositoryCustomImpl.java
+++ b/src/main/java/com/grepp/spring/app/model/study/repository/StudyMemberRepositoryCustomImpl.java
@@ -54,6 +54,10 @@ public class StudyMemberRepositoryCustomImpl implements StudyMemberRepositoryCus
                 studyMember.study.studyId.eq(studyId),
                 studyMember.activated.isTrue()
             )
+            .orderBy(
+                studyMember.studyRole.asc(),
+                studyMember.createdAt.asc()
+            )
             .fetch();
     }
 

--- a/src/main/java/com/grepp/spring/app/model/study/repository/StudyMemberRepositoryCustomImpl.java
+++ b/src/main/java/com/grepp/spring/app/model/study/repository/StudyMemberRepositoryCustomImpl.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
-public class StudyMemberRepositoryImpl implements StudyMemberRepositoryCustom {
+public class StudyMemberRepositoryCustomImpl implements StudyMemberRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
 
@@ -72,7 +72,7 @@ public class StudyMemberRepositoryImpl implements StudyMemberRepositoryCustom {
     }
 
     @Override
-    public Optional<Long> findStudyMemberIdByStudyIdWithMeberId(Long studyId, Long memberId) {
+    public Optional<Long> findStudyMemberIdByStudyIdWithMemberId(Long studyId, Long memberId) {
         Long smId = queryFactory
             .select(studyMember.studyMemberId)
             .from(studyMember)
@@ -86,14 +86,15 @@ public class StudyMemberRepositoryImpl implements StudyMemberRepositoryCustom {
     }
 
     @Override
-    public Boolean isAcceptorHasRight(Long acceptorId, Long studyId) {
+    public Boolean checkAcceptorHasRight(Long acceptorId, Long studyId) {
         return queryFactory
             .select(studyMember.studyRole.eq(StudyRole.LEADER))
             .from(studyMember)
             .where(
                 studyMember.study.studyId.eq(studyId),
                 studyMember.member.id.eq(acceptorId),
-                studyMember.activated.isTrue()
+                studyMember.activated.isTrue(),
+                studyMember.member.activated.isTrue()
             )
             .fetchOne();
     }

--- a/src/main/java/com/grepp/spring/app/model/study/repository/StudyMemberRepositoryImpl.java
+++ b/src/main/java/com/grepp/spring/app/model/study/repository/StudyMemberRepositoryImpl.java
@@ -1,0 +1,100 @@
+package com.grepp.spring.app.model.study.repository;
+
+import com.grepp.spring.app.model.member.code.StudyRole;
+import com.grepp.spring.app.model.member.entity.QMember;
+import com.grepp.spring.app.model.member.entity.QStudyMember;
+import com.grepp.spring.app.model.member.entity.StudyMember;
+import com.grepp.spring.app.model.study.entity.QStudy;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class StudyMemberRepositoryImpl implements StudyMemberRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    private static final QStudyMember studyMember = QStudyMember.studyMember;
+    private static final QStudy study = QStudy.study;
+    private static final QMember member = QMember.member;
+
+    @Override
+    public List<Long> findAllStudies(Long memberId) {
+        return queryFactory
+            .select(studyMember.studyMemberId)
+            .from(studyMember)
+            .where(
+                studyMember.member.id.eq(memberId)
+                    .and(studyMember.activated.isTrue())
+            )
+            .fetch();
+    }
+
+    @Override
+    public Optional<Long> findIdByStudyMemberIdAndMemberId(Long studyId, Long memberId) {
+        Long id =  queryFactory
+            .select(studyMember.studyMemberId)
+            .from(studyMember)
+            .where(
+                studyMember.study.studyId.eq(studyId),
+                studyMember.member.id.eq(memberId),
+                studyMember.activated.isTrue()
+            )
+            .fetchOne();
+        return Optional.ofNullable(id);
+    }
+
+    @Override
+    public List<StudyMember> findAllByStudyIdWithMember(Long studyId) {
+        return queryFactory
+            .selectFrom(studyMember)
+            .join(studyMember.member, member).fetchJoin()
+            .where(
+                studyMember.study.studyId.eq(studyId),
+                studyMember.activated.isTrue()
+            )
+            .fetch();
+    }
+
+    @Override
+    public Optional<StudyRole> findRoleByStudyAndMember(Long studyId, Long memberId) {
+        StudyRole res = queryFactory
+            .select(studyMember.studyRole)
+            .from(studyMember)
+            .where(
+                studyMember.study.studyId.eq(studyId),
+                studyMember.member.id.eq(memberId),
+                studyMember.activated.isTrue()
+            )
+            .fetchOne();
+        return Optional.ofNullable(res);
+    }
+
+    @Override
+    public Optional<Long> findStudyMemberIdByStudyIdWithMeberId(Long studyId, Long memberId) {
+        Long smId = queryFactory
+            .select(studyMember.studyMemberId)
+            .from(studyMember)
+            .where(
+                studyMember.member.id.eq(memberId),
+                studyMember.study.studyId.eq(studyId),
+                studyMember.activated.isTrue()
+            )
+            .fetchOne();
+        return Optional.ofNullable(smId);
+    }
+
+    @Override
+    public Boolean isAcceptorHasRight(Long acceptorId, Long studyId) {
+        return queryFactory
+            .select(studyMember.studyRole.eq(StudyRole.LEADER))
+            .from(studyMember)
+            .where(
+                studyMember.study.studyId.eq(studyId),
+                studyMember.member.id.eq(acceptorId),
+                studyMember.activated.isTrue()
+            )
+            .fetchOne();
+    }
+}

--- a/src/main/java/com/grepp/spring/app/model/study/repository/StudyRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/study/repository/StudyRepository.java
@@ -14,14 +14,12 @@ import org.springframework.stereotype.Repository;
 public interface StudyRepository extends JpaRepository<Study, Long>, StudyRepositoryCustom {
 
     // 지원자 목록 조회
-    @Query("SELECT new com.grepp.spring.app.model.member.dto.response.ApplicantsResponse(" +
-        "a.id, a.member.id, a.member.nickname, a.state, a.introduction, a.member.avatarImage) " +
-        "FROM Applicant a " +
-        "JOIN a.member m " +
-        "WHERE a.study.studyId = :studyId")
-    List<ApplicantsResponse> findAllApplicants(@Param("studyId") Long studyId);
-
-
+//    @Query("SELECT new com.grepp.spring.app.model.member.dto.response.ApplicantsResponse(" +
+//        "a.id, a.member.id, a.member.nickname, a.state, a.introduction, a.member.avatarImage) " +
+//        "FROM Applicant a " +
+//        "JOIN a.member m " +
+//        "WHERE a.study.studyId = :studyId")
+//    List<ApplicantsResponse> findAllApplicants(@Param("studyId") Long studyId);
 
     // goals 만 fetch join
     @Query("SELECT s FROM Study s LEFT JOIN FETCH s.goals WHERE s.studyId = :id")

--- a/src/main/java/com/grepp/spring/app/model/study/repository/StudyRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/study/repository/StudyRepository.java
@@ -1,13 +1,7 @@
 package com.grepp.spring.app.model.study.repository;
 
-import com.grepp.spring.app.model.member.dto.response.ApplicantsResponse;
-import com.grepp.spring.app.model.study.code.StudyType;
 import com.grepp.spring.app.model.study.entity.Study;
-import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -22,17 +16,17 @@ public interface StudyRepository extends JpaRepository<Study, Long>, StudyReposi
 //    List<ApplicantsResponse> findAllApplicants(@Param("studyId") Long studyId);
 
     // goals 만 fetch join
-    @Query("SELECT s FROM Study s LEFT JOIN FETCH s.goals WHERE s.studyId = :id")
-    Optional<Study> findByIdWithGoals(@Param("id") Long id);
-
-    // schedules 만 fetch join
-    @Query("SELECT s FROM Study s LEFT JOIN FETCH s.schedules WHERE s.studyId = :id")
-    Optional<Study> findByIdWithSchedules(@Param("id") Long id);
-
-    @Query("select s.studyType from Study s where s.studyId = :studyId")
-    StudyType findStudyTypeById(Long studyId);
-
-    @Query("select s.notice from Study s where s.studyId = :studyId")
-    Optional<String> findNoticeByStudyId(Long studyId);
+//    @Query("SELECT s FROM Study s LEFT JOIN FETCH s.goals WHERE s.studyId = :id")
+//    Optional<Study> findByIdWithGoals(@Param("id") Long id);
+//
+//    // schedules 만 fetch join
+//    @Query("SELECT s FROM Study s LEFT JOIN FETCH s.schedules WHERE s.studyId = :id")
+//    Optional<Study> findByIdWithSchedules(@Param("id") Long id);
+//
+//    @Query("select s.studyType from Study s where s.studyId = :studyId")
+//    StudyType findStudyTypeById(Long studyId);
+//
+//    @Query("select s.notice from Study s where s.studyId = :studyId")
+//    Optional<String> findNoticeByStudyId(Long studyId);
 }
 

--- a/src/main/java/com/grepp/spring/app/model/study/repository/StudyRepositoryCustom.java
+++ b/src/main/java/com/grepp/spring/app/model/study/repository/StudyRepositoryCustom.java
@@ -2,13 +2,12 @@ package com.grepp.spring.app.model.study.repository;
 
 import com.grepp.spring.app.controller.api.study.payload.StudySearchRequest;
 import com.grepp.spring.app.model.member.dto.response.ApplicantsResponse;
+import com.grepp.spring.app.model.study.code.StudyType;
 import com.grepp.spring.app.model.study.entity.Study;
-
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.repository.query.Param;
 
 public interface StudyRepositoryCustom {
     List<Study> searchByFilterWithSchedules(StudySearchRequest request);
@@ -18,4 +17,14 @@ public interface StudyRepositoryCustom {
     Optional<Study> findByIdWithSchedulesAndGoals(Long studyId);
 
     List<ApplicantsResponse> findAllApplicants(Long studyId);
+
+    // goals 만 fetch join
+    Optional<Study> findByIdWithGoals(Long id);
+
+    // schedules 만 fetch join
+    Optional<Study> findByIdWithSchedules(Long id);
+
+    StudyType findStudyTypeById(Long studyId);
+
+    Optional<String> findNoticeByStudyId(Long studyId);
 }

--- a/src/main/java/com/grepp/spring/app/model/study/repository/StudyRepositoryCustom.java
+++ b/src/main/java/com/grepp/spring/app/model/study/repository/StudyRepositoryCustom.java
@@ -10,21 +10,21 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface StudyRepositoryCustom {
-    List<Study> searchByFilterWithSchedules(StudySearchRequest request);
+    List<Study> searchStudiesPage(StudySearchRequest request);
 
-    Page<Study> searchByFilterWithSchedules(StudySearchRequest req, Pageable pageable);
+    Page<Study> searchStudiesPage(StudySearchRequest req, Pageable pageable);
 
     Optional<Study> findByIdWithSchedulesAndGoals(Long studyId);
 
-    List<ApplicantsResponse> findAllApplicants(Long studyId);
+    List<ApplicantsResponse> findApplicants(Long studyId);
 
     // goals 만 fetch join
-    Optional<Study> findByIdWithGoals(Long id);
+    Optional<Study> findWithGoals(Long id);
 
     // schedules 만 fetch join
-    Optional<Study> findByIdWithSchedules(Long id);
+    Optional<Study> findWithStudySchedules(Long id);
 
-    StudyType findStudyTypeById(Long studyId);
+    StudyType findStudyType(Long studyId);
 
-    Optional<String> findNoticeByStudyId(Long studyId);
+    Optional<String> findNotice(Long studyId);
 }

--- a/src/main/java/com/grepp/spring/app/model/study/repository/StudyRepositoryCustom.java
+++ b/src/main/java/com/grepp/spring/app/model/study/repository/StudyRepositoryCustom.java
@@ -1,12 +1,14 @@
 package com.grepp.spring.app.model.study.repository;
 
 import com.grepp.spring.app.controller.api.study.payload.StudySearchRequest;
+import com.grepp.spring.app.model.member.dto.response.ApplicantsResponse;
 import com.grepp.spring.app.model.study.entity.Study;
 
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.query.Param;
 
 public interface StudyRepositoryCustom {
     List<Study> searchByFilterWithSchedules(StudySearchRequest request);
@@ -14,4 +16,6 @@ public interface StudyRepositoryCustom {
     Page<Study> searchByFilterWithSchedules(StudySearchRequest req, Pageable pageable);
 
     Optional<Study> findByIdWithSchedulesAndGoals(Long studyId);
+
+    List<ApplicantsResponse> findAllApplicants(Long studyId);
 }

--- a/src/main/java/com/grepp/spring/app/model/study/repository/StudyRepositoryImpl.java
+++ b/src/main/java/com/grepp/spring/app/model/study/repository/StudyRepositoryImpl.java
@@ -18,14 +18,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
 
 import static com.grepp.spring.app.model.member.entity.QMember.member;
 import static com.grepp.spring.app.model.study.entity.QApplicant.applicant;
 import static com.grepp.spring.app.model.study.entity.QStudy.study;
 
-@Repository
 @RequiredArgsConstructor
 public class StudyRepositoryImpl implements StudyRepositoryCustom {
 
@@ -82,12 +80,12 @@ public class StudyRepositoryImpl implements StudyRepositoryCustom {
             .select(study.studyId)
             .from(study)
             .where(
-                study.activated.isTrue(),
                 (req.getCategory() != null && req.getCategory() != Category.ALL) ? study.category.eq(req.getCategory()) : null,
                 (req.getRegion() != null && req.getRegion() != Region.ALL) ? study.region.eq(req.getRegion()) : null,
                 (req.getStatus() != null && req.getStatus() != Status.ALL) ? study.status.eq(req.getStatus()) : null,
                 (req.getStudyType() != null ) ? study.studyType.eq(req.getStudyType()) : null,
-                StringUtils.hasText(req.getName()) ? study.name.contains(req.getName()) : null
+                StringUtils.hasText(req.getName()) ? study.name.contains(req.getName()) : null,
+                study.activated.isTrue()
             )
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())
@@ -119,7 +117,7 @@ public class StudyRepositoryImpl implements StudyRepositoryCustom {
                 (req.getStudyType() != null ) ? study.studyType.eq(req.getStudyType()) : null,
                 StringUtils.hasText(req.getName()) ? study.name.contains(req.getName()) : null
             )
-            .fetchFirst();
+            .fetchOne();
 
         return new PageImpl<>(content, pageable, total != null ? total : 0L);
     }

--- a/src/main/java/com/grepp/spring/app/model/study/repository/StudyRepositoryImpl.java
+++ b/src/main/java/com/grepp/spring/app/model/study/repository/StudyRepositoryImpl.java
@@ -33,7 +33,7 @@ public class StudyRepositoryImpl implements StudyRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<Study> searchByFilterWithSchedules(StudySearchRequest req) {
+    public List<Study> searchStudiesPage(StudySearchRequest req) {
         StringBuilder jpql = new StringBuilder(
             "SELECT DISTINCT s FROM Study s LEFT JOIN FETCH s.schedules WHERE 1=1");
 
@@ -75,7 +75,7 @@ public class StudyRepositoryImpl implements StudyRepositoryCustom {
     }
 
     @Override
-    public Page<Study> searchByFilterWithSchedules(StudySearchRequest req, Pageable pageable) {
+    public Page<Study> searchStudiesPage(StudySearchRequest req, Pageable pageable) {
         List<Long> ids = queryFactory
             .select(study.studyId)
             .from(study)
@@ -138,7 +138,7 @@ public class StudyRepositoryImpl implements StudyRepositoryCustom {
     }
 
     @Override
-    public List<ApplicantsResponse> findAllApplicants(Long studyId) {
+    public List<ApplicantsResponse> findApplicants(Long studyId) {
         return queryFactory
             .select(Projections.constructor(ApplicantsResponse.class,
                 applicant.id,
@@ -157,7 +157,7 @@ public class StudyRepositoryImpl implements StudyRepositoryCustom {
     }
 
     @Override
-    public Optional<Study> findByIdWithGoals(Long id) {
+    public Optional<Study> findWithGoals(Long id) {
         Study res = queryFactory
             .selectFrom(study)
             .leftJoin(study.goals).fetchJoin()
@@ -170,7 +170,7 @@ public class StudyRepositoryImpl implements StudyRepositoryCustom {
     }
 
     @Override
-    public Optional<Study> findByIdWithSchedules(Long id) {
+    public Optional<Study> findWithStudySchedules(Long id) {
         Study res = queryFactory
             .select(study)
             .from(study)
@@ -184,7 +184,7 @@ public class StudyRepositoryImpl implements StudyRepositoryCustom {
     }
 
     @Override
-    public StudyType findStudyTypeById(Long studyId) {
+    public StudyType findStudyType(Long studyId) {
         return queryFactory
             .select(study.studyType)
             .from(study)
@@ -193,7 +193,7 @@ public class StudyRepositoryImpl implements StudyRepositoryCustom {
     }
 
     @Override
-    public Optional<String> findNoticeByStudyId(Long studyId) {
+    public Optional<String> findNotice(Long studyId) {
         String res = queryFactory
             .select(study.notice)
             .from(study)

--- a/src/main/java/com/grepp/spring/app/model/study/repository/StudyRepositoryImpl.java
+++ b/src/main/java/com/grepp/spring/app/model/study/repository/StudyRepositoryImpl.java
@@ -1,10 +1,12 @@
 package com.grepp.spring.app.model.study.repository;
 
 import com.grepp.spring.app.controller.api.study.payload.StudySearchRequest;
+import com.grepp.spring.app.model.member.dto.response.ApplicantsResponse;
 import com.grepp.spring.app.model.study.code.Category;
 import com.grepp.spring.app.model.study.code.Region;
 import com.grepp.spring.app.model.study.code.Status;
 import com.grepp.spring.app.model.study.entity.Study;
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
@@ -19,6 +21,8 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 import org.springframework.util.StringUtils;
 
+import static com.grepp.spring.app.model.member.entity.QMember.member;
+import static com.grepp.spring.app.model.study.entity.QApplicant.applicant;
 import static com.grepp.spring.app.model.study.entity.QStudy.study;
 
 @Repository
@@ -129,6 +133,22 @@ public class StudyRepositoryImpl implements StudyRepositoryCustom {
             .getResultList()
             .stream()
             .findFirst();
+    }
+
+    @Override
+    public List<ApplicantsResponse> findAllApplicants(Long studyId) {
+        return queryFactory
+            .select(Projections.constructor(ApplicantsResponse.class,
+                applicant.id,
+                member.id,
+                member.nickname,
+                applicant.state,
+                applicant.introduction,
+                member.avatarImage))
+            .from(applicant)
+            .join(applicant.member, member)
+            .where(applicant.study.studyId.eq(studyId))
+            .fetch();
     }
 
 }

--- a/src/main/java/com/grepp/spring/app/model/study/service/ApplicantService.java
+++ b/src/main/java/com/grepp/spring/app/model/study/service/ApplicantService.java
@@ -24,7 +24,7 @@ public class ApplicantService {
     public void updateState(long acceptorId, long memberId, long studyId, ApplicantState state) {
         if (state == null) throw new NullStateException(ResponseCode.BAD_REQUEST);
 
-        if(!studyMemberRepository.isAcceptorHasRight(acceptorId, studyId)) {
+        if(!studyMemberRepository.checkAcceptorHasRight(acceptorId, studyId)) {
             throw new HasNotRightException(ResponseCode.UNAUTHORIZED);
         }
 

--- a/src/main/java/com/grepp/spring/app/model/study/service/StudyMemberService.java
+++ b/src/main/java/com/grepp/spring/app/model/study/service/StudyMemberService.java
@@ -73,7 +73,7 @@ public class StudyMemberService {
 
     @Transactional(readOnly = true)
     public List<CheckGoalResponse> getGoalStatuses(Long studyId, Long memberId) {
-        Long studyMemberId = studyMemberRepository.findStudyMemberIdByStudyIdWithMemberId(studyId, memberId)
+        Long studyMemberId = studyMemberRepository.findStudyMemberId(studyId, memberId)
             .orElseThrow(() -> new NotFoundException(ResponseCode.NOT_FOUND.message()));
 
         List<CheckGoalResponse> res = goalAchievementRepository.findAchieveStatuses(studyId, studyMemberId);

--- a/src/main/java/com/grepp/spring/app/model/study/service/StudyMemberService.java
+++ b/src/main/java/com/grepp/spring/app/model/study/service/StudyMemberService.java
@@ -73,10 +73,10 @@ public class StudyMemberService {
 
     @Transactional(readOnly = true)
     public List<CheckGoalResponse> getGoalStatuses(Long studyId, Long memberId) {
-        Long studyMemberId = studyMemberRepository.findStudyMemberIdByStudyIdWithMeberId(studyId, memberId)
+        Long studyMemberId = studyMemberRepository.findStudyMemberIdByStudyIdWithMemberId(studyId, memberId)
             .orElseThrow(() -> new NotFoundException(ResponseCode.NOT_FOUND.message()));
 
-        List<CheckGoalResponse> res = goalAchievementRepository.findAchieveStatusesByStudyId(studyId, studyMemberId);
+        List<CheckGoalResponse> res = goalAchievementRepository.findAchieveStatuses(studyId, studyMemberId);
         return res;
     }
 

--- a/src/main/java/com/grepp/spring/app/model/study/service/StudyService.java
+++ b/src/main/java/com/grepp/spring/app/model/study/service/StudyService.java
@@ -353,7 +353,7 @@ public class StudyService {
         Study study = studyRepository.findById(studyId)
             .orElseThrow(() -> new NotFoundException(ResponseCode.NOT_FOUND.message()));
 
-        if(!studyMemberRepository.isAcceptorHasRight(memberId, studyId)) {
+        if(!studyMemberRepository.checkAcceptorHasRight(memberId, studyId)) {
             throw new HasNotRightException(ResponseCode.UNAUTHORIZED);
         }
 

--- a/src/main/java/com/grepp/spring/app/model/study/service/StudyService.java
+++ b/src/main/java/com/grepp/spring/app/model/study/service/StudyService.java
@@ -14,7 +14,6 @@ import com.grepp.spring.app.model.study.code.ApplicantState;
 import com.grepp.spring.app.model.study.code.DayOfWeek;
 import com.grepp.spring.app.model.study.code.GoalType;
 import com.grepp.spring.app.model.study.code.Status;
-import com.grepp.spring.app.model.study.dto.StudyCreationResponse;
 import com.grepp.spring.app.model.study.code.StudyType;
 import com.grepp.spring.app.model.study.dto.StudyCreationResponse;
 import com.grepp.spring.app.model.study.dto.StudyInfoResponse;

--- a/src/main/java/com/grepp/spring/app/model/study/service/StudyService.java
+++ b/src/main/java/com/grepp/spring/app/model/study/service/StudyService.java
@@ -124,7 +124,7 @@ public class StudyService {
 
     @Transactional(readOnly = true)
     public List<GoalsResponse> findGoals(Long studyId) {
-        return studyGoalRepository.findGoalsById(studyId);
+        return studyGoalRepository.findStudyGoals(studyId);
     }
 
 

--- a/src/main/java/com/grepp/spring/app/model/study/service/StudyService.java
+++ b/src/main/java/com/grepp/spring/app/model/study/service/StudyService.java
@@ -204,7 +204,7 @@ public class StudyService {
             throw new NotFoundException("스터디가 존재하지 않습니다.");
         }
 
-        List<StudyMember> studyMembers = studyMemberRepository.findAllByStudyIdWithMember(studyId);
+        List<StudyMember> studyMembers = studyMemberRepository.findByStudyId(studyId);
 
         return studyMembers.stream()
             .map(studyMember -> {

--- a/src/main/java/com/grepp/spring/app/model/study/service/StudyService.java
+++ b/src/main/java/com/grepp/spring/app/model/study/service/StudyService.java
@@ -57,6 +57,7 @@ public class StudyService {
     private final ApplicantRepository applicantRepository;
 
     //필터 조건에 따라 스터디 목록 + 현재 인원 수 조회
+    @Transactional(readOnly = true)
     public List<StudyListResponse> searchStudiesWithMemberCount(StudySearchRequest req) {
         if (req == null) {
             throw new StudyDataException(ResponseCode.BAD_REQUEST);
@@ -188,6 +189,7 @@ public class StudyService {
         }
     }
 
+    @Transactional(readOnly = true)
     public boolean isUserStudyMember(Long memberId, Long studyId) {
         if (!studyRepository.existsById(studyId)) {
             throw new IllegalArgumentException("스터디가 존재하지 않습니다.");
@@ -197,6 +199,7 @@ public class StudyService {
     }
 
     // 스터디 멤버 조회
+    @Transactional(readOnly = true)
     public List<StudyMemberResponse> getStudyMembers(Long studyId) {
         if (!studyRepository.existsById(studyId)) {
             throw new NotFoundException("스터디가 존재하지 않습니다.");
@@ -358,6 +361,7 @@ public class StudyService {
         study.updateNotice(notice);
     }
 
+    @Transactional(readOnly = true)
     public String findNotice(Long studyId) {
         if (!studyRepository.existsById(studyId)) {
             throw new IllegalArgumentException("스터디가 존재하지 않습니다.");

--- a/src/main/java/com/grepp/spring/app/model/study/service/StudyService.java
+++ b/src/main/java/com/grepp/spring/app/model/study/service/StudyService.java
@@ -64,7 +64,7 @@ public class StudyService {
 
         Page<Study> studies;
         try {
-            studies = studyRepository.searchByFilterWithSchedules(req, req.getPageable());
+            studies = studyRepository.searchStudiesPage(req, req.getPageable());
         } catch (Exception e) {
             throw new StudyDataException(ResponseCode.FAIL_SEARCH_STUDY);
         }
@@ -119,7 +119,7 @@ public class StudyService {
     // 스터디 지원자 목록 조회
     @Transactional(readOnly = true)
     public List<ApplicantsResponse> getApplicants(Long studyId) {
-        return studyRepository.findAllApplicants(studyId);
+        return studyRepository.findApplicants(studyId);
     }
 
     @Transactional(readOnly = true)
@@ -132,11 +132,11 @@ public class StudyService {
     public StudyInfoResponse getStudyInfo(Long studyId) {
         try {
             // goals 포함 조회
-            Study studyWithGoals = studyRepository.findByIdWithGoals(studyId)
+            Study studyWithGoals = studyRepository.findWithGoals(studyId)
                 .orElseThrow(() -> new StudyDataException(ResponseCode.FAIL_GET_STUDY_INFO));
 
             // schedules 포함 조회
-            Study studyWithSchedules = studyRepository.findByIdWithSchedules(studyId)
+            Study studyWithSchedules = studyRepository.findWithStudySchedules(studyId)
                 .orElseThrow(() -> new StudyDataException(ResponseCode.FAIL_GET_STUDY_INFO));
 
             // schedules 병합
@@ -345,7 +345,7 @@ public class StudyService {
     }
 
     public boolean isSurvival(Long studyId) {
-        return (StudyType.SURVIVAL == studyRepository.findStudyTypeById(studyId));
+        return (StudyType.SURVIVAL == studyRepository.findStudyType(studyId));
     }
 
     @Transactional
@@ -366,7 +366,7 @@ public class StudyService {
             throw new IllegalArgumentException("스터디가 존재하지 않습니다.");
         }
 
-        return studyRepository.findNoticeByStudyId(studyId)
+        return studyRepository.findNotice(studyId)
             .orElse("공지사항이 없습니다.");
     }
 }

--- a/src/main/java/com/grepp/spring/app/model/timer/service/TimerService.java
+++ b/src/main/java/com/grepp/spring/app/model/timer/service/TimerService.java
@@ -80,7 +80,7 @@ public class TimerService {
     @Transactional
     public void recordStudyTime(Long studyId, Long memberId, StudyTimeRecordRequest req) {
 
-        Long studyMemberId = studyMemberRepository.findStudyMemberIdByStudyIdWithMeberId(studyId, memberId)
+        Long studyMemberId = studyMemberRepository.findStudyMemberIdByStudyIdWithMemberId(studyId, memberId)
             .orElseThrow(() -> new NotFoundException("Study Member Not Found"));
 
         Timer timer = Timer.builder()

--- a/src/main/java/com/grepp/spring/app/model/timer/service/TimerService.java
+++ b/src/main/java/com/grepp/spring/app/model/timer/service/TimerService.java
@@ -47,7 +47,7 @@ public class TimerService {
 
     @Transactional
     public List<DailyStudyLogResponse> findDailyStudyLogsByStudyMemberId(Long studyId, Long memberId) {
-        Long studyMemberId = studyMemberRepository.findIdByStudyMemberIdAndMemberId(studyId, memberId)
+        Long studyMemberId = studyMemberRepository.findStudyMemberId(studyId, memberId)
             .orElseThrow(() -> new NotFoundException("Study Member Not Found"));
         LocalDateTime endOfDay = LocalDateTime.now();
         LocalDateTime startOfDay = endOfDay.toLocalDate().minusDays(6).atStartOfDay();
@@ -64,7 +64,7 @@ public class TimerService {
 
     @Transactional(readOnly = true)
     public StudyWeekTimeResponse getStudyTimeForPeriod(Long studyId, Long memberId) {
-        Long studyMemberId = studyMemberRepository.findIdByStudyMemberIdAndMemberId(studyId, memberId)
+        Long studyMemberId = studyMemberRepository.findStudyMemberId(studyId, memberId)
             .orElseThrow(() -> new NotFoundException("Study Member Not Found"));
 
         LocalDateTime endOfDay = LocalDateTime.now();
@@ -80,7 +80,7 @@ public class TimerService {
     @Transactional
     public void recordStudyTime(Long studyId, Long memberId, StudyTimeRecordRequest req) {
 
-        Long studyMemberId = studyMemberRepository.findStudyMemberIdByStudyIdWithMemberId(studyId, memberId)
+        Long studyMemberId = studyMemberRepository.findStudyMemberId(studyId, memberId)
             .orElseThrow(() -> new NotFoundException("Study Member Not Found"));
 
         Timer timer = Timer.builder()

--- a/src/main/java/com/grepp/spring/infra/auth/role/StudyRoleCheckAspect.java
+++ b/src/main/java/com/grepp/spring/infra/auth/role/StudyRoleCheckAspect.java
@@ -43,7 +43,7 @@ public class StudyRoleCheckAspect {
         StudyRole[] requiredRoles = checkStudyRole.value();
 
         // 실제 역할
-        StudyRole userRoleInStudy = studyMemberRepository.findRoleByStudyAndMember(studyId, memberId)
+        StudyRole userRoleInStudy = studyMemberRepository.findStudyRole(studyId, memberId)
             .orElseThrow(() -> new AccessDeniedException("해당 스터디에 가입되지않았습니다."));
 
         boolean isAuthorized = Arrays.stream(requiredRoles)

--- a/src/test/java/com/grepp/spring/app/model/study/StudyServiceTest.java
+++ b/src/test/java/com/grepp/spring/app/model/study/StudyServiceTest.java
@@ -41,7 +41,7 @@ class StudyServiceTest {
         );
 
         // studyRepository.findAllApplicants(studyId) 메서드가 호출되면, expectedResponses 리스트를 반환
-        when(studyRepository.findAllApplicants(studyId)).thenReturn(expectedResponses);
+        when(studyRepository.findApplicants(studyId)).thenReturn(expectedResponses);
 
         // when
         List<ApplicantsResponse> actualResponses = studyService.getApplicants(studyId);
@@ -54,7 +54,7 @@ class StudyServiceTest {
         assertThat(actualResponses.get(1).getState()).isEqualTo(ApplicantState.ACCEPT);
 
         // studyRepository.findAllApplicants(studyId)가 정확히 1번 호출되었는지 검증
-        verify(studyRepository, times(1)).findAllApplicants(studyId);
+        verify(studyRepository, times(1)).findApplicants(studyId);
     }
 
 

--- a/src/test/java/com/grepp/spring/app/model/study/service/StudyServiceTest.java
+++ b/src/test/java/com/grepp/spring/app/model/study/service/StudyServiceTest.java
@@ -35,12 +35,12 @@ class StudyServiceTest {
             new GoalsResponse(3L, "자주쓰는 원어민 표현 100개 외우기")
         );
 
-        when(studyGoalRepository.findGoalsById(studyId)).thenReturn(expectedGoals);
+        when(studyGoalRepository.findStudyGoals(studyId)).thenReturn(expectedGoals);
 
         List<GoalsResponse> actualResponse = studyService.findGoals(studyId);
 
         assertEquals(expectedGoals, actualResponse);
-        verify(studyGoalRepository, times(1)).findGoalsById(studyId);
+        verify(studyGoalRepository, times(1)).findStudyGoals(studyId);
     }
 
 }


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
study관련으로 사용된 repository에서 JPQL로 구현된 메서드들 중 일부를 QueryDSL로 변경하였습니다.'
원래는 어제 오전에 끝났었지만 서버올리는 과정 중 JPA 자동생성과 충돌이나는 문제가 생겨 기능확인 후 오늘 올리네요.
- 해당 문제는 Impl클래스의 네이밍 문제였습니다. GoalRepositoryCustom하고 구현체는 GoalRepositoryCustomImpl이라 네이밍을 해야 JPA 이름기반 쿼리생성기능이 작동하지 않더라구요...

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
### GoalRepositoryCustom
- findAchieveStatuses 변경 (StudyController 맴버의 특정 스터디에 대한 목표 달성여부 체크)
- findGoalsById 변경 (StudyController 스터디 목표 조회와 관련)
    -> findStudyGoals로 변경

### StudyMemberRepositoryCustom
- findAllStudies(TimerController 타이머 전체 누적 시간 조회와 관련)
- findIdByStudyMemberIdAndMemberId (TimerController 스터디별 7일간의 일별 공부시간 확인, 스터디별 7일간의 누적 공부 시간 확인 관련) 
    -> findStudyMemberIdByStudyIdWithMemberId삭제 후 findStudyMemberId로 메서드명 변경
- findAllByStudyIdWithMember (스터디 맴버 리스트 조회와 관련)
    -> findByStudyId로 변경
    - 추가적으로 Leader가 항상 첫번째에 오고 맴버는 먼저 참가한 순으로 조회되도록 변경하였습니다.
- findRoleByStudyAndMember(스터디 인가 어노테이션 관련)
    -> findStudyRole로 변경
- findStudyMemberIdByStudyIdWithMemberId (StudyController 스터디 목표 달성 여부 조회, TimerController 공부시간 등록관련) -> 삭제(findAllByStudyIdWithMember와 동작동일)
- checkAcceptorHasRight (StudyController 스터디 가입 승인/거절,  스터디 공지사항 수정 관련)

###  StudyRepositoryCustom
- searchByFilterWithSchedules 
    -> searchStudiesPage로 변경
- findAllApplicants  (StudyController 스터디 신청자 목록 조회 관련)
    -> findApplicants로 변경
- findByIdWithGoals (StudyController 스터디 정보 조회 관련)
    -> findWithGoals로 변경
- findByIdWithSchedules (StudyController 스터디 정보 조회 관련)
    -> findWithStudySchedules로 변경
- findStudyTypeById (StudyController 스터디 가입 승인/거절 관련)
    -> findStudyType로 변경
- findNoticeByStudyId (StudyController 스터디 공지사항 조회 관련)
    -> findNotice로 변경

테스트는 user1과 user5로 하였습니다.
## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
QueryDSL적용 및 메서드명 변경(인자를 굳이 메서드에 포함시키지 마라)

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
