### PR TITLE
Refactor: 알림 서비스 QueryDSL 변경

### DIFF
--- a/src/main/java/com/grepp/spring/app/controller/api/alarm/AlarmController.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/alarm/AlarmController.java
@@ -1,7 +1,7 @@
 package com.grepp.spring.app.controller.api.alarm;
 
 import com.grepp.spring.app.controller.api.alarm.payload.AlarmRequest;
-import com.grepp.spring.app.model.alarm.dto.AlarmListResponse;
+import com.grepp.spring.app.controller.api.alarm.payload.AlarmListResponse;
 import com.grepp.spring.app.model.alarm.service.AlarmService;
 import com.grepp.spring.app.model.alarm.sse.EmitterRepository;
 import com.grepp.spring.infra.response.CommonResponse;

--- a/src/main/java/com/grepp/spring/app/controller/api/alarm/payload/AlarmListResponse.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/alarm/payload/AlarmListResponse.java
@@ -1,4 +1,4 @@
-package com.grepp.spring.app.model.alarm.dto;
+package com.grepp.spring.app.controller.api.alarm.payload;
 
 import com.grepp.spring.app.model.alarm.entity.Alarm;
 import com.grepp.spring.app.model.alarm.entity.AlarmRecipient;

--- a/src/main/java/com/grepp/spring/app/model/alarm/repository/AlarmRecipientRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/alarm/repository/AlarmRecipientRepository.java
@@ -1,11 +1,7 @@
 package com.grepp.spring.app.model.alarm.repository;
 
 import com.grepp.spring.app.model.alarm.entity.AlarmRecipient;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository

--- a/src/main/java/com/grepp/spring/app/model/alarm/repository/AlarmRecipientRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/alarm/repository/AlarmRecipientRepository.java
@@ -9,20 +9,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface AlarmRecipientRepository extends JpaRepository<AlarmRecipient, Long> {
-
-    @Query("""
-            SELECT ar
-            FROM AlarmRecipient ar
-            JOIN FETCH ar.alarm a
-            LEFT JOIN FETCH a.sender s
-            WHERE ar.member.id = :memberId
-            ORDER BY a.createdAt DESC
-    """)
-    List<AlarmRecipient> findAllWithSenderByMemberId(@Param("memberId") Long memberId);
-
-    @Modifying(clearAutomatically = true)
-    @Query("UPDATE AlarmRecipient ar SET ar.isRead = true WHERE ar.member.id = :memberId AND ar.isRead = false")
-    int markAllAsReadByMemberId(@Param("memberId") Long memberId);
+public interface AlarmRecipientRepository extends JpaRepository<AlarmRecipient, Long>,
+    AlarmRecipientRepositoryCustom {
 
 }

--- a/src/main/java/com/grepp/spring/app/model/alarm/repository/AlarmRecipientRepositoryCustom.java
+++ b/src/main/java/com/grepp/spring/app/model/alarm/repository/AlarmRecipientRepositoryCustom.java
@@ -1,0 +1,12 @@
+package com.grepp.spring.app.model.alarm.repository;
+
+import com.grepp.spring.app.model.alarm.entity.AlarmRecipient;
+import java.util.List;
+
+public interface AlarmRecipientRepositoryCustom {
+
+    List<AlarmRecipient> findMyAlarms(Long memberId);
+
+    void markAllAsRead(Long memberId);
+
+}

--- a/src/main/java/com/grepp/spring/app/model/alarm/repository/AlarmRecipientRepositoryImpl.java
+++ b/src/main/java/com/grepp/spring/app/model/alarm/repository/AlarmRecipientRepositoryImpl.java
@@ -1,0 +1,44 @@
+package com.grepp.spring.app.model.alarm.repository;
+
+import com.grepp.spring.app.model.alarm.entity.AlarmRecipient;
+import com.grepp.spring.app.model.alarm.entity.QAlarm;
+import com.grepp.spring.app.model.alarm.entity.QAlarmRecipient;
+import com.grepp.spring.app.model.member.entity.QMember;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+public class AlarmRecipientRepositoryImpl implements AlarmRecipientRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<AlarmRecipient> findMyAlarms(Long memberId) {
+
+        QAlarmRecipient ar = QAlarmRecipient.alarmRecipient;
+        QAlarm a = QAlarm.alarm;
+        QMember m = QMember.member;
+
+        return queryFactory
+            .selectFrom(ar)
+            .join(ar.alarm, a).fetchJoin()
+            .leftJoin(a.sender, m).fetchJoin()
+            .where(ar.member.id.eq(memberId))
+            .orderBy(a.createdAt.desc())
+            .fetch();
+    }
+
+    @Override
+    @Transactional
+    public void markAllAsRead(Long memberId) {
+        QAlarmRecipient ar = QAlarmRecipient.alarmRecipient;
+
+        queryFactory
+            .update(ar)
+            .set(ar.isRead, true)
+            .where(ar.member.id.eq(memberId).and(ar.isRead.isFalse()))
+            .execute();
+    }
+}

--- a/src/main/java/com/grepp/spring/app/model/alarm/service/AlarmService.java
+++ b/src/main/java/com/grepp/spring/app/model/alarm/service/AlarmService.java
@@ -2,7 +2,7 @@ package com.grepp.spring.app.model.alarm.service;
 
 import com.grepp.spring.app.controller.api.alarm.payload.AlarmRequest;
 import com.grepp.spring.app.model.alarm.code.AlarmType;
-import com.grepp.spring.app.model.alarm.dto.AlarmListResponse;
+import com.grepp.spring.app.controller.api.alarm.payload.AlarmListResponse;
 import com.grepp.spring.app.model.alarm.entity.Alarm;
 import com.grepp.spring.app.model.alarm.entity.AlarmRecipient;
 import com.grepp.spring.app.model.alarm.repository.AlarmRecipientRepository;
@@ -101,7 +101,7 @@ public class AlarmService {
     // 알림 목록 조회
     @Transactional(readOnly = true)
     public List<AlarmListResponse> getAlarmsByMemberId(Long memberId) {
-        List<AlarmRecipient> recipients = alarmRecipientRepository.findAllWithSenderByMemberId(memberId);
+        List<AlarmRecipient> recipients = alarmRecipientRepository.findMyAlarms(memberId);
 
         return recipients.stream()
             .map(AlarmListResponse::new)
@@ -127,6 +127,6 @@ public class AlarmService {
     // 알림 모두 읽음 처리
     @Transactional
     public void markAllAlarmsAsRead(Long memberId) {
-        alarmRecipientRepository.markAllAsReadByMemberId(memberId);
+        alarmRecipientRepository.markAllAsRead(memberId);
     }
 }


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- 알림 서비스: 기존 JPQL로 구현되어 있던 부분을 QueryDSL로 변경했습니다.
- AlarmListResponse dto 클래스를 api>payload로 이동했습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
### 메서드명 변경 사항
- findAllWithSenderByMemberId -> findMyAlarms (자신의 알림 목록 조회)
- markAllAsReadByMemberId -> markAllAsRead (알림 전체 읽음 처리)

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 중간 피드백 반영하여 리팩토링 진행했습니다. (QueryDSL 적용, 메서드 네이밍 수정)