### PR TITLE
Refactor: 스터디 목표 달성 여부 조회 수정

### DIFF
--- a/src/main/java/com/grepp/spring/app/controller/api/study/payload/WeeklyAchievementCount.java
+++ b/src/main/java/com/grepp/spring/app/controller/api/study/payload/WeeklyAchievementCount.java
@@ -1,0 +1,16 @@
+package com.grepp.spring.app.controller.api.study.payload;
+
+import lombok.Getter;
+
+@Getter
+public class WeeklyAchievementCount {
+
+    private final String week;
+    private final Long count;
+
+    public WeeklyAchievementCount(Object week, Long count) {
+        this.week = String.valueOf(week);
+        this.count = count;
+    }
+
+}

--- a/src/main/java/com/grepp/spring/app/model/study/dto/WeeklyGoalStatusResponse.java
+++ b/src/main/java/com/grepp/spring/app/model/study/dto/WeeklyGoalStatusResponse.java
@@ -10,8 +10,6 @@ import lombok.Getter;
 public class WeeklyGoalStatusResponse {
 
     private Long studyId;
-    private LocalDate startDate;
-    private LocalDate endDate;
     private List<GoalStat> goals;
 
     @Getter

--- a/src/main/java/com/grepp/spring/app/model/study/dto/WeeklyGoalStatusResponse.java
+++ b/src/main/java/com/grepp/spring/app/model/study/dto/WeeklyGoalStatusResponse.java
@@ -17,7 +17,8 @@ public class WeeklyGoalStatusResponse {
     @Getter
     @AllArgsConstructor
     public static class GoalStat {
-        private int completedCount;
+        private String week;
+        private Long count;
     }
 }
 

--- a/src/main/java/com/grepp/spring/app/model/study/entity/GoalAchievement.java
+++ b/src/main/java/com/grepp/spring/app/model/study/entity/GoalAchievement.java
@@ -1,6 +1,7 @@
 package com.grepp.spring.app.model.study.entity;
 
 import com.grepp.spring.app.model.member.entity.StudyMember;
+import com.grepp.spring.infra.entity.BaseEntity;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
 import lombok.*;
@@ -8,7 +9,7 @@ import lombok.*;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class GoalAchievement {
+public class GoalAchievement extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -24,18 +25,14 @@ public class GoalAchievement {
 
     private boolean isAccomplished;
 
-    private boolean activated;
-
     private LocalDateTime achievedAt;
 
     @Builder
     public GoalAchievement(StudyGoal studyGoal, StudyMember studyMember,
-        boolean isAccomplished, boolean activated,
-        LocalDateTime achievedAt) {
+        boolean isAccomplished, LocalDateTime achievedAt) {
         this.studyGoal = studyGoal;
         this.studyMember = studyMember;
         this.isAccomplished = isAccomplished;
-        this.activated = activated;
         this.achievedAt = achievedAt;
     }
 }

--- a/src/main/java/com/grepp/spring/app/model/study/entity/StudyGoal.java
+++ b/src/main/java/com/grepp/spring/app/model/study/entity/StudyGoal.java
@@ -1,6 +1,7 @@
 package com.grepp.spring.app.model.study.entity;
 
 import com.grepp.spring.app.model.study.code.GoalType;
+import com.grepp.spring.infra.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -10,7 +11,7 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class StudyGoal {
+public class StudyGoal extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -21,8 +22,6 @@ public class StudyGoal {
     @Enumerated(EnumType.STRING)
     private GoalType goalType;
 
-    private boolean activated;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "study_id", nullable = false)
     private Study study;
@@ -31,10 +30,9 @@ public class StudyGoal {
     private List<GoalAchievement> achievements = new ArrayList<>();
 
     @Builder
-    public StudyGoal(String content, GoalType goalType, boolean activated, Study study) {
+    public StudyGoal(String content, GoalType goalType, Study study) {
         this.content = content;
         this.goalType = goalType;
-        this.activated = activated;
         this.study = study;
     }
 

--- a/src/main/java/com/grepp/spring/app/model/study/repository/GoalRepositoryCustom.java
+++ b/src/main/java/com/grepp/spring/app/model/study/repository/GoalRepositoryCustom.java
@@ -1,14 +1,17 @@
 package com.grepp.spring.app.model.study.repository;
 
 import com.grepp.spring.app.controller.api.study.payload.CheckGoalResponse;
+import com.grepp.spring.app.controller.api.study.payload.WeeklyAchievementCount;
 import com.grepp.spring.app.model.study.reponse.GoalsResponse;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface GoalRepositoryCustom {
-    List<CheckGoalResponse> findAchieveStatuses(Long studyId, Long studyMemberId);
+    List<CheckGoalResponse> findAchieveStatuses(Long studyId, Long studyMemberId, LocalDateTime now);
 
     List<GoalsResponse> findStudyGoals(Long studyId);
 
 //    int getTotalAchievementsCount(Long studyId, Long studyMemberId, LocalDateTime startDateTime, LocalDateTime endDateTime);
 
+    List<WeeklyAchievementCount> countWeeklyAchievements(Long studyId, Long studyMemberId, LocalDateTime startDateTime, LocalDateTime endDateTime);
 }

--- a/src/main/java/com/grepp/spring/app/model/study/repository/GoalRepositoryCustomImpl.java
+++ b/src/main/java/com/grepp/spring/app/model/study/repository/GoalRepositoryCustomImpl.java
@@ -47,7 +47,7 @@ public class GoalRepositoryCustomImpl implements GoalRepositoryCustom {
                 studyGoal.goalId.eq(goalAchievement.studyGoal.goalId),
                 goalAchievement.studyMember.studyMemberId.eq(studyMemberId),
                 goalAchievement.activated.isTrue(),
-                goalAchievement.createdAt.between(startOfWeek, now)
+                goalAchievement.achievedAt.between(startOfWeek, now)
             )
             .where(
                 studyGoal.study.studyId.eq(studyId),

--- a/src/main/java/com/grepp/spring/app/model/study/repository/GoalRepositoryCustomImpl.java
+++ b/src/main/java/com/grepp/spring/app/model/study/repository/GoalRepositoryCustomImpl.java
@@ -85,7 +85,7 @@ public class GoalRepositoryCustomImpl implements GoalRepositoryCustom {
         NumberTemplate<Integer> weekExpression = Expressions.numberTemplate(Integer.class,
             "FLOOR((EXTRACT(EPOCH FROM {0}) - EXTRACT(EPOCH FROM {1})) / 604800) + 1",
             goalAchievement.achievedAt,
-            studyGoal.study.createdAt
+            studyGoal.study.startDate
         );
 
         return queryFactory

--- a/src/main/java/com/grepp/spring/app/model/study/service/StudyMemberService.java
+++ b/src/main/java/com/grepp/spring/app/model/study/service/StudyMemberService.java
@@ -12,6 +12,7 @@ import com.grepp.spring.app.model.study.repository.StudyRepository;
 import com.grepp.spring.infra.error.exceptions.AlreadyExistException;
 import com.grepp.spring.infra.error.exceptions.NotFoundException;
 import com.grepp.spring.infra.response.ResponseCode;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -75,8 +76,8 @@ public class StudyMemberService {
     public List<CheckGoalResponse> getGoalStatuses(Long studyId, Long memberId) {
         Long studyMemberId = studyMemberRepository.findStudyMemberId(studyId, memberId)
             .orElseThrow(() -> new NotFoundException(ResponseCode.NOT_FOUND.message()));
-
-        List<CheckGoalResponse> res = goalAchievementRepository.findAchieveStatuses(studyId, studyMemberId);
+        List<CheckGoalResponse> res = goalAchievementRepository
+            .findAchieveStatuses(studyId, studyMemberId, LocalDateTime.now());
         return res;
     }
 

--- a/src/test/java/com/grepp/spring/app/model/quiz/service/QuizGetServiceTest.java
+++ b/src/test/java/com/grepp/spring/app/model/quiz/service/QuizGetServiceTest.java
@@ -2,7 +2,7 @@ package com.grepp.spring.app.model.quiz.service;
 
 import com.grepp.spring.app.controller.api.quiz.payload.QuizListResponse;
 import com.grepp.spring.app.model.quiz.dto.QuizProjection;
-import com.grepp.spring.app.model.quiz.repository.QuizSetRepository;
+import com.grepp.spring.app.model.quiz.repository.quizSetRepository.QuizSetRepository;
 import com.grepp.spring.app.model.study.repository.StudyRepository;
 import com.grepp.spring.infra.error.exceptions.Quiz.InvalidQuizException;
 import com.grepp.spring.infra.error.exceptions.Quiz.MemberNotFoundException;


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
스터디 목표 달성이 기존에 최근 7일간의 데이터를 주는 것으로 이야기가 되었으나 
변경요청이 와서 전체 기간을 주별로 나누어 개수를 카운팅하도록 변경하였습니다.

추가적으로 맴버의 특정 스터디에 대한 목표 달성여부 체크 부분도 변경사항이 필요해 이를 변경했습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
StudyGoal과 GoalAchievement에 BaseEntity를 상속받지않고 activated만 필드를 하드하게 추가해두었길래 이를 지우고 BaseEntity를 상속 받아 **CreatedAt과 ModifiedAt**, Ativated를 추가하였습니다.
**DB에 필드가 추가될 수 있습니다.**

테스트 환경은 studyId가 1이고 현재 더미데이터 상 2025-08-01인데 테스트를 위해 2025-07-01로 변경 후 테스트 하였습니다.
user1으로 테스트 했으며 user1은 studyId 1에서 3개의 목표 중 goalId 1,2를 07-24에 달성하여 4주차에 2개를 달성하고 나머지는 0이 나와야 정상입니다.

현재 요구받은 /{studyId}/goals/completed 요청은 Study의 startDate와 요청받은 Date까지 일주일 단위로 잘라 주차를 계산하고 있습니다.
<img width="1215" height="1110" alt="주간 스터디 목표 달성 현황 조회 _수정" src="https://github.com/user-attachments/assets/9fea348e-61a3-4f2c-be27-866f82090f61" />

추가적으로 /{studyId}/check-goal에 대해서도 현재 주차의 달성정보를 가져오도록 하였습니다.
그런데 이건 주차를 해당 날에 대해 가장 가까운 월요일부터 현재 날까지의 기간을 현재 주로 보고있습니다.
<img width="1215" height="1110" alt="스터디 목표 달성 여부 조회 _ 수정" src="https://github.com/user-attachments/assets/ed8fbd11-1ba5-4cc4-9abb-da87f90c86f7" />

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
Service로직이나 QueryDSL로직에 제가 이상하게 한 부분이 있는지 봐주시면 감사하겠습니다.
이거는 로직이 심하게 복잡해졌는데 애초부터 엔티티설계에 이 기능들을 염두해두었다면 이렇게까지 복잡해지지 않았을까 싶네요.
