### PR TITLE
Refactor: MemberRepository QueryDSL로 리팩토링

### DIFF
--- a/src/main/java/com/grepp/spring/app/model/chat/service/ChatService.java
+++ b/src/main/java/com/grepp/spring/app/model/chat/service/ChatService.java
@@ -18,14 +18,12 @@ import com.grepp.spring.infra.config.Chat.WebSocket.WebSocketSessionTracker;
 import com.grepp.spring.infra.error.exceptions.NotFoundException;
 import java.time.LocalDateTime;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -50,12 +48,12 @@ public class ChatService {
         ChatRoom chatRoom = chatRoomRepository.findByStudy_StudyId(studyId)
             .orElseThrow(() -> new NotFoundException("Invalid studyId"));
 
-        String nickname = memberRepository.findNicknameById(senderId);
+        String nickname = memberRepository.getNickname(senderId);
 
 
 
         Chat chat = request.toEntity(chatRoom, senderId, nickname);
-        String image = memberRepository.findAvatarImageById(senderId);
+        String image = memberRepository.getAvatarImage(senderId);
         System.out.println("senderId: " + senderId + ", image: " + image);
 
         chatRepository.save(chat);

--- a/src/main/java/com/grepp/spring/app/model/member/repository/MemberRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/member/repository/MemberRepository.java
@@ -1,35 +1,13 @@
 package com.grepp.spring.app.model.member.repository;
 
-import com.grepp.spring.app.model.member.dto.response.RequiredMemberInfoResponse;
 import com.grepp.spring.app.model.member.entity.Member;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom{
 
     Optional<Member> findByEmail(String email);
 
-    @Query("SELECT m.id FROM Member m WHERE m.email = :email")
-    Long findIdByEmail(@Param("email") String email);
-
-
-    @Query("SELECT m.nickname FROM Member m WHERE m.id = :id")
-    String findNicknameById(@Param("id")Long Id);
-
-    @Query("select new com.grepp.spring.app.model.member.dto.response.RequiredMemberInfoResponse"
-        + "(m.id, m.email, m.nickname, m.birthday, m.gender, m.rewardPoints, m.winCount, m.socialType, m.role) "
-        + "from Member m where m.activated = true and m.id = :memberId")
-    RequiredMemberInfoResponse findRequiredMemberInfo(@Param("memberId") Long memberId);
-
-    @Query("select m.avatarImage  from Member m where m.id = :memberId")
-    String findAvatarImageById(@Param("memberId") Long memberId);
-
-    @Modifying(clearAutomatically = true)
-    @Query("UPDATE Member m SET m.rewardPoints = m.rewardPoints + :points WHERE m.id = :memberId")
-    void addRewardPoints(@Param("memberId") Long memberId, @Param("points") int points);
 }

--- a/src/main/java/com/grepp/spring/app/model/member/repository/MemberRepositoryCustom.java
+++ b/src/main/java/com/grepp/spring/app/model/member/repository/MemberRepositoryCustom.java
@@ -1,0 +1,17 @@
+package com.grepp.spring.app.model.member.repository;
+
+import com.grepp.spring.app.model.member.dto.response.RequiredMemberInfoResponse;
+
+public interface MemberRepositoryCustom {
+
+    Long findIdByEmail(String email);
+
+    String getNickname(Long id);
+
+    RequiredMemberInfoResponse getRequiredMemberInfo(Long memberId);
+
+    String getAvatarImage(Long memberId);
+
+    void addRewardPoints(Long memberId, int points);
+
+}

--- a/src/main/java/com/grepp/spring/app/model/member/repository/MemberRepositoryImpl.java
+++ b/src/main/java/com/grepp/spring/app/model/member/repository/MemberRepositoryImpl.java
@@ -1,0 +1,80 @@
+package com.grepp.spring.app.model.member.repository;
+
+import static com.grepp.spring.app.model.member.entity.QMember.member;
+
+import com.grepp.spring.app.model.member.dto.response.RequiredMemberInfoResponse;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberRepositoryImpl implements MemberRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+    private final EntityManager em;
+
+    @Override
+    public Long findIdByEmail(String email) {
+        return queryFactory
+            .select(member.id)
+            .from(member)
+            .where(member.email.eq(email))
+            .fetchOne();
+    }
+
+    @Override
+    public String getNickname(Long id) {
+        return queryFactory
+            .select(member.nickname)
+            .from(member)
+            .where(member.id.eq(id))
+            .fetchOne();
+    }
+
+    @Override
+    public RequiredMemberInfoResponse getRequiredMemberInfo(Long memberId) {
+        return queryFactory
+            .select(Projections.constructor(
+                RequiredMemberInfoResponse.class,
+                member.id,
+                member.email,
+                member.nickname,
+                member.birthday,
+                member.gender,
+                member.rewardPoints,
+                member.winCount,
+                member.socialType,
+                member.role
+            ))
+            .from(member)
+            .where(member.activated.isTrue()
+                .and(member.id.eq(memberId)))
+            .fetchOne();
+    }
+
+    @Override
+    public String getAvatarImage(Long memberId) {
+        return queryFactory
+            .select(member.avatarImage)
+            .from(member)
+            .where(member.id.eq(memberId))
+            .fetchOne();
+    }
+
+    @Override
+    @Transactional
+    public void addRewardPoints(Long memberId, int points) {
+        queryFactory
+            .update(member)
+            .set(member.rewardPoints, member.rewardPoints.add(points))
+            .where(member.id.eq(memberId))
+            .execute();
+        em.flush();
+        em.clear();
+    }
+}
+

--- a/src/main/java/com/grepp/spring/app/model/member/service/MemberService.java
+++ b/src/main/java/com/grepp/spring/app/model/member/service/MemberService.java
@@ -306,13 +306,13 @@ public class MemberService {
 
     @Transactional(readOnly = true)
     public RequiredMemberInfoResponse getMemberRequiredInfo(Long memberId) {
-        return memberRepository.findRequiredMemberInfo(memberId);
+        return memberRepository.getRequiredMemberInfo(memberId);
     }
 
     @Transactional(readOnly = true)
     public AvatarInfoResponse getMemberAvatarInfo(Long memberId) {
         List<Long> ids = ownItemIdGetRepository.findIdsByMemberId(memberId);
-        String memberAvatarImage = memberRepository.findAvatarImageById(memberId);
+        String memberAvatarImage = memberRepository.getAvatarImage(memberId);
         AvatarInfoResponse avatarInfoResponse = AvatarInfoResponse.builder()
             .itemIds(ids)
             .avatarImage(memberAvatarImage)

--- a/src/main/java/com/grepp/spring/infra/config/Chat/WebSocket/Participants/WebSocketEventListener.java
+++ b/src/main/java/com/grepp/spring/infra/config/Chat/WebSocket/Participants/WebSocketEventListener.java
@@ -42,8 +42,8 @@ public class WebSocketEventListener {
 
             long memberId = principal.getMemberId();
             String email = principal.getUsername();
-            String nickname = memberRepository.findNicknameById(memberId);
-            String image = memberRepository.findAvatarImageById(memberId);
+            String nickname = memberRepository.getNickname(memberId);
+            String image = memberRepository.getAvatarImage(memberId);
 
             String studyIdHeader = accessor.getFirstNativeHeader("studyId");
             String sessionId = accessor.getSessionId();


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- MemberRepository에 JPQL로 구현되었던 메서드를 QueryDSL로 리팩토링 했습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
### 메서드명 변경 사항
- findNicknameById -> getNickname (멤버 닉네임 조회)
- findRequiredMemberInfo -> getRequiredMemberInfo (멤버 전체 정보 조회) 
- findAvatarImageById -> getAvatarImage (멤버 아바타 조회)

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 채팅 부분은 테스트를 못해서 잘 동작하겠죠...?