### PR TITLE
Fix : auth filter 인가 처리

### DIFF
--- a/src/main/java/com/grepp/spring/infra/auth/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/grepp/spring/infra/auth/jwt/filter/JwtAuthenticationFilter.java
@@ -39,11 +39,30 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final MemberRepository memberRepository;
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
-        List<String> excludePath = new ArrayList<>();
-        excludePath.addAll(List.of("/auth/signup", "/auth/login",  "/favicon.ico", "/img", "/js","/css","/download"));
-        excludePath.addAll(List.of("/error", "/api/member/exists", "/member/signin", "/member/signup"));
         String path = request.getRequestURI();
-        return excludePath.stream().anyMatch(path::startsWith);
+
+        // 정적 경로 리스트
+        List<String> staticExcludePaths = List.of(
+            "/auth/signup", "/auth/login", "/favicon.ico", "/img", "/js", "/css", "/download",
+            "/error", "/api/member/exists", "/member/signin", "/member/signup",
+            "/api/v1/studies/search", "/api/v1/studies/categories"
+        );
+
+        // 정적 경로
+        if (staticExcludePaths.stream().anyMatch(path::startsWith)) {
+            return true;
+        }
+
+        // 동적 경로 리스트
+        List<String> dynamicExcludePatterns = List.of(
+            "^/api/v1/studies/\\d+$",                // /api/v1/studies/{studyId}
+            "^/api/v1/studies/\\d+/notification$",   // /api/v1/studies/{studyId}/notification
+            "^/api/v1/studies/\\d+/members$",        // /api/v1/studies/{studyId}/members
+            "^/api/v1/studies/\\d+/goals$"           // /api/v1/studies/{studyId}/goals
+        );
+
+        // matches로 정규식 패턴을 확인
+        return dynamicExcludePatterns.stream().anyMatch(path::matches);
     }
     
     @Override

--- a/src/main/java/com/grepp/spring/infra/auth/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/grepp/spring/infra/auth/jwt/filter/JwtAuthenticationFilter.java
@@ -42,7 +42,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         List<String> excludePath = new ArrayList<>();
         excludePath.addAll(List.of("/favicon.ico", "/img", "/js","/css","/download"));
         excludePath.addAll(List.of("/error", "/api/member/exists", "/member/signin", "/member/signup"));
-        excludePath.addAll(List.of("/api/v1/auth/signup", "/api/v1/auth/login", "/api/v1/auth/reissue", "/api/v1/auth/email", "/api/v1/auth/oauth"));
+        excludePath.addAll(List.of("/api/v1/auth/signup", "/api/v1/auth/login", "/api/v1/auth/reissue", "/api/v1/auth/email", "/api/v1/auth/oauth/first-regist"));
         excludePath.addAll(List.of("/api/v1/studies/search", "/api/v1/studies/categories"));
         String path = request.getRequestURI();
         return excludePath.stream().anyMatch(path::startsWith);

--- a/src/main/java/com/grepp/spring/infra/auth/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/grepp/spring/infra/auth/jwt/filter/JwtAuthenticationFilter.java
@@ -39,30 +39,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final MemberRepository memberRepository;
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        List<String> excludePath = new ArrayList<>();
+        excludePath.addAll(List.of("/favicon.ico", "/img", "/js","/css","/download"));
+        excludePath.addAll(List.of("/error", "/api/member/exists", "/member/signin", "/member/signup"));
+        excludePath.addAll(List.of("/api/v1/auth/signup", "/api/v1/auth/login", "/api/v1/auth/reissue", "/api/v1/auth/email", "/api/v1/auth/oauth"));
+        excludePath.addAll(List.of("/api/v1/studies/search", "/api/v1/studies/categories"));
         String path = request.getRequestURI();
-
-        // 정적 경로 리스트
-        List<String> staticExcludePaths = List.of(
-            "/favicon.ico", "/img", "/js", "/css", "/download", "/error",
-            "/api/v1/auth/signup", "/api/v1/auth/login", "/api/v1/auth/reissue", "/api/v1/auth/email", "/api/v1/auth/oauth",
-            "/api/v1/studies/search", "/api/v1/studies/categories"
-        );
-
-        // 정적 경로
-        if (staticExcludePaths.stream().anyMatch(path::startsWith)) {
-            return true;
-        }
-
-        // 동적 경로 리스트
-        List<String> dynamicExcludePatterns = List.of(
-            "^/api/v1/studies/\\d+$",                // /api/v1/studies/{studyId}
-            "^/api/v1/studies/\\d+/notification$",   // /api/v1/studies/{studyId}/notification
-            "^/api/v1/studies/\\d+/members$",        // /api/v1/studies/{studyId}/members
-            "^/api/v1/studies/\\d+/goals$"           // /api/v1/studies/{studyId}/goals
-        );
-
-        // matches로 정규식 패턴을 확인
-        return dynamicExcludePatterns.stream().anyMatch(path::matches);
+        return excludePath.stream().anyMatch(path::startsWith);
     }
     
     @Override

--- a/src/main/java/com/grepp/spring/infra/auth/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/grepp/spring/infra/auth/jwt/filter/JwtAuthenticationFilter.java
@@ -43,8 +43,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         // 정적 경로 리스트
         List<String> staticExcludePaths = List.of(
-            "/auth/signup", "/auth/login", "/favicon.ico", "/img", "/js", "/css", "/download",
-            "/error", "/api/member/exists", "/member/signin", "/member/signup",
+            "/favicon.ico", "/img", "/js", "/css", "/download", "/error",
+            "/api/v1/auth/signup", "/api/v1/auth/login", "/api/v1/auth/reissue", "/api/v1/auth/email", "/api/v1/auth/oauth",
             "/api/v1/studies/search", "/api/v1/studies/categories"
         );
 

--- a/src/main/java/com/grepp/spring/infra/config/security/SecurityConfig.java
+++ b/src/main/java/com/grepp/spring/infra/config/security/SecurityConfig.java
@@ -31,7 +31,7 @@ public class SecurityConfig {
     
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final JwtExceptionFilter jwtExceptionFilter;
-    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+//    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
     private final OAuth2FailureHandler oAuth2FailureHandler;
     

--- a/src/main/java/com/grepp/spring/infra/config/security/SecurityConfig.java
+++ b/src/main/java/com/grepp/spring/infra/config/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.grepp.spring.infra.config.security;
 
+import com.grepp.spring.infra.auth.jwt.JwtAuthenticationEntryPoint;
 import com.grepp.spring.infra.auth.jwt.filter.JwtAuthenticationFilter;
 import com.grepp.spring.infra.auth.jwt.filter.JwtExceptionFilter;
 import com.grepp.spring.infra.auth.oauth2.OAuth2FailureHandler;
@@ -28,7 +29,7 @@ public class SecurityConfig {
     
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final JwtExceptionFilter jwtExceptionFilter;
-//    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
     private final OAuth2FailureHandler oAuth2FailureHandler;
     
@@ -49,14 +50,18 @@ public class SecurityConfig {
             .logout(AbstractHttpConfigurer::disable)
             .authorizeHttpRequests(
                 (requests) -> requests
-//                    .requestMatchers("/favicon.ico", "/img/**", "/js/**","/css/**").permitAll()
-//                    .requestMatchers("/", "/error", "/auth/login", "/auth/signup").permitAll()
-//                    .requestMatchers("/api/v1/studies/search").permitAll()
-//                    .anyRequest().authenticated()
-                    .anyRequest().permitAll()
+                    .requestMatchers("/favicon.ico", "/img/**", "/js/**","/css/**").permitAll()
+                    .requestMatchers("/", "/error", "/auth/login", "/auth/signup").permitAll()
+                    .requestMatchers("/api/v1/studies/search", "/api/v1/studies/categories").permitAll()
+                    .requestMatchers("/api/v1/studies/*").permitAll()
+                    .requestMatchers("/api/v1/studies/*/notification").permitAll()
+                    .requestMatchers("/api/v1/studies/*/members").permitAll()
+                    .requestMatchers("/api/v1/studies/*/goals").permitAll()
+                    .anyRequest().authenticated()
+//                    .anyRequest().permitAll()
             )
             // jwtAuthenticationEntryPoint 는 oauth 인증을 사용할 경우 제거
-//            .exceptionHandling(ex -> ex.authenticationEntryPoint(jwtAuthenticationEntryPoint))
+            .exceptionHandling(ex -> ex.authenticationEntryPoint(jwtAuthenticationEntryPoint))
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
             .addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class);
         return http.build();

--- a/src/main/java/com/grepp/spring/infra/config/security/SecurityConfig.java
+++ b/src/main/java/com/grepp/spring/infra/config/security/SecurityConfig.java
@@ -53,7 +53,8 @@ public class SecurityConfig {
             .authorizeHttpRequests(
                 (requests) -> requests
                     .requestMatchers("/favicon.ico", "/img/**", "/js/**","/css/**").permitAll()
-                    .requestMatchers("/", "/error", "/auth/login", "/auth/signup").permitAll()
+                    .requestMatchers("/", "/error").permitAll()
+                    .requestMatchers("/api/v1/auth/signup", "/api/v1/auth/login", "/api/v1/auth/email/**", "/api/v1/auth/oauth/first-regist").permitAll()
                     .requestMatchers("/api/v1/studies/search", "/api/v1/studies/categories").permitAll()
                     .requestMatchers(GET,"/api/v1/studies/*").permitAll()
                     .requestMatchers(GET,"/api/v1/studies/*/notification").permitAll()

--- a/src/main/java/com/grepp/spring/infra/config/security/SecurityConfig.java
+++ b/src/main/java/com/grepp/spring/infra/config/security/SecurityConfig.java
@@ -21,6 +21,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+import static org.springframework.http.HttpMethod.GET;
+
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity(prePostEnabled = true)
@@ -53,10 +55,10 @@ public class SecurityConfig {
                     .requestMatchers("/favicon.ico", "/img/**", "/js/**","/css/**").permitAll()
                     .requestMatchers("/", "/error", "/auth/login", "/auth/signup").permitAll()
                     .requestMatchers("/api/v1/studies/search", "/api/v1/studies/categories").permitAll()
-                    .requestMatchers("/api/v1/studies/*").permitAll()
-                    .requestMatchers("/api/v1/studies/*/notification").permitAll()
-                    .requestMatchers("/api/v1/studies/*/members").permitAll()
-                    .requestMatchers("/api/v1/studies/*/goals").permitAll()
+                    .requestMatchers(GET,"/api/v1/studies/*").permitAll()
+                    .requestMatchers(GET,"/api/v1/studies/*/notification").permitAll()
+                    .requestMatchers(GET,"/api/v1/studies/*/members").permitAll()
+                    .requestMatchers(GET,"/api/v1/studies/*/goals").permitAll()
                     .anyRequest().authenticated()
 //                    .anyRequest().permitAll()
             )

--- a/src/main/java/com/grepp/spring/infra/config/security/SecurityConfig.java
+++ b/src/main/java/com/grepp/spring/infra/config/security/SecurityConfig.java
@@ -61,7 +61,7 @@ public class SecurityConfig {
 //                    .anyRequest().permitAll()
             )
             // jwtAuthenticationEntryPoint 는 oauth 인증을 사용할 경우 제거
-            .exceptionHandling(ex -> ex.authenticationEntryPoint(jwtAuthenticationEntryPoint))
+//            .exceptionHandling(ex -> ex.authenticationEntryPoint(jwtAuthenticationEntryPoint))
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
             .addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class);
         return http.build();


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
이제 프로젝트도 끝나가니 인가 로직을 활성화 시켰습니다.
추가적으로 스터디 목록 검색이나 카테고리, 스터디 정보보기, 공지, 스터디맴버, 목표 조회 요청을 비로그인시에도 접근이 되지않을까하는 생각에 같이 풀어두고 jwt필터에서도 빼두었습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
현재 jwt인가필터에서 제외되는 요청은
- AuthController
    - 회원가입 "/api/v1/auth/signup",
    - 로그인  "/api/v1/auth/login", 
    - 토큰 재발급 "/api/v1/auth/reissue", 
    - 이메일 인증 및 확인 "/api/v1/auth/email", 
    - 소셜로그인 상세 정보 입력 "/api/v1/auth/oauth/first-regist",
- StudyController
    -  스터디 목록 검색 "/api/v1/studies/search", 
    - 스터디 카테고리 조회 "/api/v1/studies/categories"
목표나 맴버, 공지쪽은 SecurityFilterChain쪽에서 Get요청만 permitAll()로 열어두었습니다.
jwt인가필터쪽에서 하면 혹시나 delete나 patch, put 요청이 추가되면 해당 요청이 인가처리가 사라져 조금 늦더라도 securityFilterChain에서 처리해 두었습니다.

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
**혹시 인가에 대해 수정사항이 있다면 알려주세요!!!!**

jwtAuthenticationEntryPoint는 동작 시기 상 Oauth2랑 충돌날것같진 않은데 혹시 모르니 그대로 추가하지 않았습니다.
