### PR TITLE
Refactor: study search N+1문제 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security' // Spring Security를 위한 스타터
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf' // Thymeleaf 템플릿 엔진을 위한 스타터
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta' // QUeryDSL JPA
+    implementation 'org.springframework.boot:spring-boot-starter-amqp'
 
     // https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-websocket
     implementation("org.springframework.boot:spring-boot-starter-websocket:3.4.4")

--- a/src/main/java/com/grepp/spring/app/model/study/dto/StudyListResponse.java
+++ b/src/main/java/com/grepp/spring/app/model/study/dto/StudyListResponse.java
@@ -6,37 +6,55 @@ import com.grepp.spring.app.model.study.code.Status;
 import com.grepp.spring.app.model.study.code.StudyType;
 import com.grepp.spring.app.model.study.entity.Study;
 import com.grepp.spring.app.model.study.entity.StudySchedule;
-import java.time.LocalDate;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Getter
-@Builder
 public class StudyListResponse {
 
-    private Long studyId;
-    private String title;
-    private Category category;
-    private int currentMemberCount;
-    private int maxMemberCount;
-    private List<String> schedules;
-    private String startTime;
-    private String endTime;
-    private Status status;
-    private String createdAt;
-    private LocalDate startDate;
-    private Region region;
-    private StudyType studyType;
-    private String description;
+    private final Long studyId;
+    private final String title;
+    private final Category category;
+    private final int currentMemberCount;
+    private final int maxMemberCount;
+    private final List<String> schedules;
+    private final String startTime;
+    private final String endTime;
+    private final Status status;
+    private final String createdAt;
+    private final LocalDate startDate;
+    private final Region region;
+    private final StudyType studyType;
+    private final String description;
 
-    public static StudyListResponse fromEntity(Study study, int currentMemberCount) {
-        List<StudySchedule> scheduleList = study.getSchedules();
+    @Builder
+    public StudyListResponse(Long studyId, String title, Category category, int currentMemberCount,
+        int maxMemberCount, List<String> schedules, String startTime, String endTime,
+        Status status, String createdAt, LocalDate startDate, Region region,
+        StudyType studyType, String description) {
+        this.studyId = studyId;
+        this.title = title;
+        this.category = category;
+        this.currentMemberCount = currentMemberCount;
+        this.maxMemberCount = maxMemberCount;
+        this.schedules = schedules;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.status = status;
+        this.createdAt = createdAt;
+        this.startDate = startDate;
+        this.region = region;
+        this.studyType = studyType;
+        this.description = description;
+    }
 
+    public static StudyListResponse fromEntity(Study study, int currentMemberCount, List<StudySchedule> scheduleList) {
         // 요일 리스트 추출
         List<String> days = scheduleList != null
             ? scheduleList.stream()

--- a/src/main/java/com/grepp/spring/app/model/study/repository/StudyRepositoryCustom.java
+++ b/src/main/java/com/grepp/spring/app/model/study/repository/StudyRepositoryCustom.java
@@ -3,6 +3,7 @@ package com.grepp.spring.app.model.study.repository;
 import com.grepp.spring.app.controller.api.study.payload.StudySearchRequest;
 import com.grepp.spring.app.model.member.dto.response.ApplicantsResponse;
 import com.grepp.spring.app.model.study.code.StudyType;
+import com.grepp.spring.app.model.study.dto.StudyListResponse;
 import com.grepp.spring.app.model.study.entity.Study;
 import java.util.List;
 import java.util.Optional;
@@ -27,4 +28,6 @@ public interface StudyRepositoryCustom {
     StudyType findStudyType(Long studyId);
 
     Optional<String> findNotice(Long studyId);
+
+    Page<StudyListResponse> searchStudiesWithMemberCount(StudySearchRequest req, Pageable pageable);
 }

--- a/src/main/java/com/grepp/spring/app/model/study/repository/StudyRepositoryImpl.java
+++ b/src/main/java/com/grepp/spring/app/model/study/repository/StudyRepositoryImpl.java
@@ -9,7 +9,6 @@ import com.grepp.spring.app.model.study.code.StudyType;
 import com.grepp.spring.app.model.study.dto.StudyListResponse;
 import com.grepp.spring.app.model.study.entity.Study;
 import com.grepp.spring.app.model.study.entity.StudySchedule;
-import com.querydsl.core.group.GroupBy;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
@@ -27,7 +26,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
@@ -36,7 +34,6 @@ import static com.grepp.spring.app.model.member.entity.QStudyMember.studyMember;
 import static com.grepp.spring.app.model.study.entity.QApplicant.applicant;
 import static com.grepp.spring.app.model.study.entity.QStudy.study;
 import static com.grepp.spring.app.model.study.entity.QStudySchedule.studySchedule;
-import static com.querydsl.jpa.JPAExpressions.select;
 
 @Slf4j
 @RequiredArgsConstructor

--- a/src/main/java/com/grepp/spring/app/model/study/repository/StudyRepositoryImpl.java
+++ b/src/main/java/com/grepp/spring/app/model/study/repository/StudyRepositoryImpl.java
@@ -6,24 +6,37 @@ import com.grepp.spring.app.model.study.code.Category;
 import com.grepp.spring.app.model.study.code.Region;
 import com.grepp.spring.app.model.study.code.Status;
 import com.grepp.spring.app.model.study.code.StudyType;
+import com.grepp.spring.app.model.study.dto.StudyListResponse;
 import com.grepp.spring.app.model.study.entity.Study;
+import com.grepp.spring.app.model.study.entity.StudySchedule;
+import com.querydsl.core.group.GroupBy;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.TypedQuery;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
 import static com.grepp.spring.app.model.member.entity.QMember.member;
+import static com.grepp.spring.app.model.member.entity.QStudyMember.studyMember;
 import static com.grepp.spring.app.model.study.entity.QApplicant.applicant;
 import static com.grepp.spring.app.model.study.entity.QStudy.study;
+import static com.grepp.spring.app.model.study.entity.QStudySchedule.studySchedule;
+import static com.querydsl.jpa.JPAExpressions.select;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -213,6 +226,102 @@ public class StudyRepositoryImpl implements StudyRepositoryCustom {
             )
             .fetchOne();
         return Optional.ofNullable(res);
+    }
+
+    @Override
+    public Page<StudyListResponse> searchStudiesWithMemberCount(StudySearchRequest req, Pageable pageable) {
+
+        // 페이징이 적용 studyId 목록
+        List<Long> ids = queryFactory
+            .select(study.studyId)
+            .from(study)
+            .where(searchConditions(req))
+            .orderBy(study.createdAt.desc(), study.studyId.desc())
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+        if (CollectionUtils.isEmpty(ids)) {
+            return new PageImpl<>(Collections.emptyList(), pageable, 0);
+        }
+
+        // 스터디 조회
+        List<Study> studies = queryFactory
+            .selectFrom(study)
+            .where(study.studyId.in(ids))
+            .orderBy(study.createdAt.desc(), study.studyId.desc())
+            .fetch();
+
+        // 멤버 수를 조회, Map으로 변환
+        Map<Long, Long> memberCountsMap = queryFactory
+            .select(studyMember.study.studyId, studyMember.count())
+            .from(studyMember)
+            .where(studyMember.study.studyId.in(ids))
+            .groupBy(studyMember.study.studyId)
+            .fetch()
+            .stream()
+            .collect(Collectors.toMap(
+                tuple -> tuple.get(0, Long.class), // key: studyId
+                tuple -> tuple.get(1, Long.class)  // value: member count
+            ));
+
+        // 스케줄 정보 조회
+        List<StudySchedule> schedules = queryFactory
+            .selectFrom(studySchedule)
+            .where(studySchedule.study.studyId.in(ids))
+            .fetch();
+
+        // 스케줄을 studyId 기준으로 그룹화, Map으로 변환
+        Map<Long, List<StudySchedule>> schedulesMap = schedules.stream()
+            .collect(Collectors.groupingBy(s -> s.getStudy().getStudyId()));
+
+        // DTO 리스트 생성
+        List<StudyListResponse> content = studies.stream()
+            .map(s -> {
+                int currentMemberCount = memberCountsMap.getOrDefault(s.getStudyId(), 0L).intValue();
+                List<StudySchedule> studySchedules = schedulesMap.getOrDefault(s.getStudyId(), Collections.emptyList());
+                return StudyListResponse.fromEntity(s, currentMemberCount, studySchedules);
+            })
+            .collect(Collectors.toList());
+
+        // 전체 카운트 조회
+        JPAQuery<Long> countQuery = queryFactory
+            .select(study.count())
+            .from(study)
+            .where(searchConditions(req));
+
+        return new PageImpl<>(content, pageable, countQuery.fetchOne());
+    }
+
+    private BooleanExpression[] searchConditions(StudySearchRequest req) {
+        return new BooleanExpression[] {
+            categoryEq(req.getCategory()),
+            regionEq(req.getRegion()),
+            statusEq(req.getStatus()),
+            studyTypeEq(req.getStudyType()),
+            nameContains(req.getName()),
+            study.activated.isTrue()
+        };
+    }
+
+    private BooleanExpression categoryEq(Category category) {
+        return (category != null && category != Category.ALL) ? study.category.eq(category) : null;
+    }
+
+    private BooleanExpression regionEq(Region region) {
+        return (region != null && region != Region.ALL) ? study.region.eq(region) : null;
+    }
+
+    private BooleanExpression statusEq(Status status) {
+        return (status != null && status != Status.ALL) ? study.status.eq(status) : null;
+    }
+
+    private BooleanExpression studyTypeEq(StudyType studyType) {
+        return (studyType != null) ? study.studyType.eq(studyType) : null;
+    }
+
+    private BooleanExpression nameContains(String name) {
+        return StringUtils.hasText(name) ? study.name.contains(name) : null;
     }
 
 }

--- a/src/main/java/com/grepp/spring/app/model/study/service/StudyService.java
+++ b/src/main/java/com/grepp/spring/app/model/study/service/StudyService.java
@@ -60,41 +60,51 @@ public class StudyService {
     private final ApplicantRepository applicantRepository;
 
     //필터 조건에 따라 스터디 목록 + 현재 인원 수 조회
+//    @Transactional(readOnly = true)
+//    public List<StudyListResponse> searchStudiesWithMemberCount(StudySearchRequest req) {
+//        if (req == null) {
+//            throw new StudyDataException(ResponseCode.BAD_REQUEST);
+//        }
+//
+//        Page<Study> studies;
+//        try {
+//            studies = studyRepository.searchStudiesPage(req, req.getPageable());
+//        } catch (Exception e) {
+//            throw new StudyDataException(ResponseCode.FAIL_SEARCH_STUDY);
+//        }
+//
+//        return studies.getContent().stream()
+//            .map(study -> {
+//                if (study.getStudyId() == null) {
+//                    throw new StudyDataException(ResponseCode.FAIL_SEARCH_STUDY);
+//                }
+//
+//                int currentMemberCount;
+//                try {
+//                    currentMemberCount = studyMemberRepository.countByStudy_StudyId(study.getStudyId());
+//                } catch (Exception e) {
+//                    throw new StudyDataException(ResponseCode.FAIL_SEARCH_STUDY);
+//                }
+//
+//                try {
+//                    return StudyListResponse.fromEntity(study, currentMemberCount);
+//                } catch (Exception e) {
+//                    throw new StudyDataException(ResponseCode.FAIL_SEARCH_STUDY);
+//                }
+//            })
+//            .collect(Collectors.toList());
+//    }
+
     @Transactional(readOnly = true)
     public List<StudyListResponse> searchStudiesWithMemberCount(StudySearchRequest req) {
         if (req == null) {
             throw new StudyDataException(ResponseCode.BAD_REQUEST);
         }
 
-        Page<Study> studies;
-        try {
-            studies = studyRepository.searchStudiesPage(req, req.getPageable());
-        } catch (Exception e) {
-            throw new StudyDataException(ResponseCode.FAIL_SEARCH_STUDY);
-        }
+        Page<StudyListResponse> pageResult = studyRepository.searchStudiesWithMemberCount(req, req.getPageable());
 
-        return studies.getContent().stream()
-            .map(study -> {
-                if (study.getStudyId() == null) {
-                    throw new StudyDataException(ResponseCode.FAIL_SEARCH_STUDY);
-                }
-
-                int currentMemberCount;
-                try {
-                    currentMemberCount = studyMemberRepository.countByStudy_StudyId(study.getStudyId());
-                } catch (Exception e) {
-                    throw new StudyDataException(ResponseCode.FAIL_SEARCH_STUDY);
-                }
-
-                try {
-                    return StudyListResponse.fromEntity(study, currentMemberCount);
-                } catch (Exception e) {
-                    throw new StudyDataException(ResponseCode.FAIL_SEARCH_STUDY);
-                }
-            })
-            .collect(Collectors.toList());
+        return pageResult.getContent();
     }
-
 
 
     @Transactional


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
스터디 목록 조회의 성능을 개선시켰습니다.

현재 스터디 목록 조회는 먼저 페이지네이션으로 스터디 페이지 정보들을 받아오고 
이 목록에 대해 추가적인 쿼리로 각 스터디의 인원을 체크하는 구조로 1번의 요청으로 페이지를 받아오는 쿼리와 추가적으로 스터디들에 대해 각각 카운팅을 하는 방식의 로직이기에 성능을 크게 해치고 있었습니다.

해당 요청은 유저가 가장 많이 사용하는 요청이기에 성능개선의 필요성을 느껴 위 문제를 해결할 수 있도록 변경하였습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
해당 문제를 해결하기 위해 DTO와 QueryDSL을 크게 수정하였습니다.

StudyListResponse
- Bulider를 클래스단에서 선언하지 않고 내부에서 생성자를 만들어 붙여두었습니다.
- fromEntity를 수정하였습니다.

StudyRepositoryImpl
searchStudiesWithMemberCount생성하였습니다.
- ids에 페이징을 적용해 id들을 받아옵니다.
- 이를 이용해 스터디를 조회하고 이때 정렬도 적용합니다
- studyId를 통해 맴버를 카운팅하고 map으로 저장해둡니다.
- 스케쥴 정보를 studyId를 이용해 조회하고 studyId를 기준으로 그룹화하고 Map으로 저장합니다
- DTO에 이를 stream을 이용해 매핑해 저장합니다.

jmeter 설정은 user 1000에 period 0 loop 1이였습니다.
**수정 전**
<img width="1671" height="1217" alt="(report) before Studies_search" src="https://github.com/user-attachments/assets/6576f8d9-04e6-462d-8bfd-8131aced8172" />

**수정 후**
<img width="2160" height="1264" alt="(report) after Studies_search" src="https://github.com/user-attachments/assets/cd3c9770-5ff3-4490-8bb4-cbfec3bc15e0" />

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
배포 적용 후 문제가 없다면 기존의 로직을 지우겠습니다.
