### PR TITLE
Refactor: findByStudyStudyIdAndMemberId 제거 후 findStudyMember 생성

### DIFF
--- a/src/main/java/com/grepp/spring/app/model/member/repository/StudyMemberRepository.java
+++ b/src/main/java/com/grepp/spring/app/model/member/repository/StudyMemberRepository.java
@@ -13,8 +13,6 @@ public interface StudyMemberRepository extends JpaRepository<StudyMember, Long>,
 
     List<StudyMember> findByMemberId(Long memberId);
 
-    Optional<StudyMember> findByStudyStudyIdAndMemberId(Long studyId, Long memberId);
-
     Optional<StudyMember> findByMember_IdAndStudy_StudyId(Long memberId, Long studyId);
 
     int countByStudy_StudyId(Long studyId);

--- a/src/main/java/com/grepp/spring/app/model/study/repository/StudyMemberRepositoryCustom.java
+++ b/src/main/java/com/grepp/spring/app/model/study/repository/StudyMemberRepositoryCustom.java
@@ -11,6 +11,8 @@ public interface StudyMemberRepositoryCustom {
 
     List<StudyMember> findByStudyId(Long studyId);
 
+    Optional<StudyMember> findStudyMember(Long studyId, Long memberId);
+
     Optional<StudyRole> findStudyRole(Long studyId, Long memberId);
 
     Optional<Long> findStudyMemberId(Long studyId, Long memberId);

--- a/src/main/java/com/grepp/spring/app/model/study/repository/StudyMemberRepositoryCustomImpl.java
+++ b/src/main/java/com/grepp/spring/app/model/study/repository/StudyMemberRepositoryCustomImpl.java
@@ -62,6 +62,21 @@ public class StudyMemberRepositoryCustomImpl implements StudyMemberRepositoryCus
     }
 
     @Override
+    public Optional<StudyMember> findStudyMember(Long studyId, Long memberId) {
+        StudyMember res = queryFactory
+            .select(studyMember)
+            .from(studyMember)
+            .where(
+                studyMember.study.studyId.eq(studyId),
+                studyMember.member.id.eq(memberId),
+                studyMember.member.activated.isTrue(),
+                studyMember.study.activated.isTrue()
+            )
+            .fetchOne();
+        return Optional.ofNullable(res);
+    }
+
+    @Override
     public Optional<StudyRole> findStudyRole(Long studyId, Long memberId) {
         StudyRole res = queryFactory
             .select(studyMember.studyRole)

--- a/src/main/java/com/grepp/spring/app/model/study/service/StudyService.java
+++ b/src/main/java/com/grepp/spring/app/model/study/service/StudyService.java
@@ -116,7 +116,7 @@ public class StudyService {
 
         StudyGoal studyGoal = studyGoalRepository.findById(goalId)
             .orElseThrow(() -> new NotFoundException("해당 목표를 찾을 수 없습니다."));
-        StudyMember studyMember = studyMemberRepository.findByStudyStudyIdAndMemberId(studyId, memberId)
+        StudyMember studyMember = studyMemberRepository.findStudyMember(studyId, memberId)
             .orElseThrow(() -> new NotFoundException("스터디 멤버 정보를 찾을 수 없습니다."));
 
         GoalAchievement newAchievement = GoalAchievement.builder()
@@ -351,7 +351,7 @@ public class StudyService {
         LocalDateTime startDateTime = startDate.atStartOfDay();
         LocalDateTime endDateTime = endDate.atTime(LocalTime.MAX);
 
-        StudyMember studyMember = studyMemberRepository.findByStudyStudyIdAndMemberId(studyId, memberId)
+        StudyMember studyMember = studyMemberRepository.findStudyMember(studyId, memberId)
             .orElseThrow(() -> new NotFoundException("스터디 멤버 정보를 찾을 수 없습니다."));
         Long studyMemberId = studyMember.getStudyMemberId();
 


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
findByStudyStudyIdAndMemberId의 메서드 명이 길어 메서드 이름기반 쿼리가 아닌 querydsl을 사용해 메서드명을 간단하게 할 수 있도록 변경하였습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
findByStudyStudyIdAndMemberId 제거 후 findStudyMember 생성
해당 메서드는 member, study가 삭제(activated=false)되지 않은 경우에 대해 studyId와 memberId가 동일한 StudyMember를 가져옵니다.

테스트는 user2@example.com으로 studyId 3에 대해 했습니다.(user2는 studyId 3에 가입되지 않은 유저입니다)

- 목표 달성 등록
<img width="1392" height="1483" alt="Screenshot 2025-07-28 at 11 16 47 AM" src="https://github.com/user-attachments/assets/b58bd3ef-dbf0-4d2b-94ba-f57b1382ce9c" />

- 주간 스터디 목표 달성 현황 조회
<img width="1392" height="1483" alt="Screenshot 2025-07-28 at 11 16 32 AM" src="https://github.com/user-attachments/assets/389abb94-eb87-4f65-867e-08f976873a2f" />

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
메서드명 수정, quereydsl 사용

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
이거 아마 다빈님의 Optional<StudyMember> findByMember_IdAndStudy_StudyId(Long memberId, Long studyId)과 동일한 기능같은데 맞다면 이걸로 바꾸면 될 것같습니다.
