### PR TITLE
Fix: 스터디 신청자 목록 조회 인가 로직 취소

### DIFF
--- a/src/main/java/com/grepp/spring/app/model/study/service/StudyService.java
+++ b/src/main/java/com/grepp/spring/app/model/study/service/StudyService.java
@@ -140,10 +140,6 @@ public class StudyService {
     // 스터디 지원자 목록 조회
     @Transactional(readOnly = true)
     public List<ApplicantsResponse> getApplicants(Long studyId) {
-        Long memberId = SecurityUtil.getCurrentMemberId();
-        if (!studyMemberRepository.checkAcceptorHasRight(memberId, studyId)) {
-            throw new HasNotRightException(ResponseCode.UNAUTHORIZED);
-        }
         return studyRepository.findApplicants(studyId);
     }
 

--- a/src/main/java/com/grepp/spring/infra/config/security/SecurityConfig.java
+++ b/src/main/java/com/grepp/spring/infra/config/security/SecurityConfig.java
@@ -60,7 +60,6 @@ public class SecurityConfig {
                     .requestMatchers(GET,"/api/v1/studies/*/notification").permitAll()
                     .requestMatchers(GET,"/api/v1/studies/*/members").permitAll()
                     .requestMatchers(GET,"/api/v1/studies/*/goals").permitAll()
-                    .requestMatchers(GET,"/api/v1/studies/*/applications-list").permitAll()
                     .anyRequest().authenticated()
 //                    .anyRequest().permitAll()
             )

--- a/src/main/java/com/grepp/spring/infra/config/security/SecurityConfig.java
+++ b/src/main/java/com/grepp/spring/infra/config/security/SecurityConfig.java
@@ -60,6 +60,7 @@ public class SecurityConfig {
                     .requestMatchers(GET,"/api/v1/studies/*/notification").permitAll()
                     .requestMatchers(GET,"/api/v1/studies/*/members").permitAll()
                     .requestMatchers(GET,"/api/v1/studies/*/goals").permitAll()
+                    .requestMatchers(GET,"/api/v1/studies/*/applications-list").permitAll()
                     .anyRequest().authenticated()
 //                    .anyRequest().permitAll()
             )


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
현재 신청자 확인을 같은 api로 하기때문에 신청자 목록에 대한 get요청은 인가처리를 풀어두도록 하겠습니다.
로직 상에서 스터디장인지 확인하는 과정을 지워두었습니다.