### PR TITLE
Refactor: admin auth 처리

### DIFF
--- a/src/main/java/com/grepp/spring/app/model/member/repository/MemberRepositoryCustom.java
+++ b/src/main/java/com/grepp/spring/app/model/member/repository/MemberRepositoryCustom.java
@@ -1,5 +1,6 @@
 package com.grepp.spring.app.model.member.repository;
 
+import com.grepp.spring.app.model.auth.code.Role;
 import com.grepp.spring.app.model.member.dto.response.RequiredMemberInfoResponse;
 
 public interface MemberRepositoryCustom {
@@ -14,4 +15,5 @@ public interface MemberRepositoryCustom {
 
     void addRewardPoints(Long memberId, int points);
 
+    Role findRole(Long memberId);
 }

--- a/src/main/java/com/grepp/spring/app/model/member/repository/MemberRepositoryImpl.java
+++ b/src/main/java/com/grepp/spring/app/model/member/repository/MemberRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.grepp.spring.app.model.member.repository;
 
 import static com.grepp.spring.app.model.member.entity.QMember.member;
 
+import com.grepp.spring.app.model.auth.code.Role;
 import com.grepp.spring.app.model.member.dto.response.RequiredMemberInfoResponse;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -75,6 +76,18 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
             .execute();
         em.flush();
         em.clear();
+    }
+
+    @Override
+    public Role findRole(Long memberId) {
+        return queryFactory
+            .select(member.role)
+            .from(member)
+            .where(
+                member.activated.isTrue(),
+                member.id.eq(memberId)
+            )
+            .fetchOne();
     }
 }
 

--- a/src/main/java/com/grepp/spring/app/model/member/repository/StudyMemberRepositoryCustomImpl.java
+++ b/src/main/java/com/grepp/spring/app/model/member/repository/StudyMemberRepositoryCustomImpl.java
@@ -2,6 +2,7 @@ package com.grepp.spring.app.model.member.repository;
 
 import static com.grepp.spring.app.model.member.entity.QStudyMember.studyMember;
 
+import com.grepp.spring.app.model.auth.code.Role;
 import com.grepp.spring.app.model.member.code.StudyRole;
 import com.grepp.spring.app.model.member.entity.QMember;
 import com.grepp.spring.app.model.member.entity.QStudyMember;
@@ -83,7 +84,7 @@ public class StudyMemberRepositoryCustomImpl implements StudyMemberRepositoryCus
     @Override
     public Boolean checkAcceptorHasRight(Long memberId, Long studyId) {
         Boolean result = queryFactory
-            .select(sm.studyRole.eq(StudyRole.LEADER))
+            .select(sm.studyRole.eq(StudyRole.LEADER).or(sm.member.role.eq(Role.ROLE_ADMIN)))
             .from(sm)
             .where(
                 sm.study.studyId.eq(studyId),

--- a/src/main/java/com/grepp/spring/app/model/study/service/StudyService.java
+++ b/src/main/java/com/grepp/spring/app/model/study/service/StudyService.java
@@ -8,6 +8,7 @@ import com.grepp.spring.app.controller.api.study.payload.StudyUpdateRequest;
 import com.grepp.spring.app.controller.api.study.payload.WeeklyAchievementCount;
 import com.grepp.spring.app.model.alarm.code.AlarmType;
 import com.grepp.spring.app.model.alarm.service.AlarmService;
+import com.grepp.spring.app.model.auth.code.Role;
 import com.grepp.spring.app.model.member.code.StudyRole;
 import com.grepp.spring.app.model.member.dto.response.ApplicantsResponse;
 import com.grepp.spring.app.model.member.dto.response.StudyMemberResponse;
@@ -290,6 +291,10 @@ public class StudyService {
         Member leader = memberRepository.findById(memberId)
             .orElseThrow(() -> new NotFoundException("회원 정보를 찾을 수 없습니다."));
 
+        if(req.getStudyType().equals(StudyType.SURVIVAL) && memberRepository.findRole(memberId) == Role.ROLE_USER) {
+            throw new HasNotRightException(ResponseCode.UNAUTHORIZED);
+        }
+
         // 1. 스터디 생성
         Study study = Study.builder()
             .name(req.getName())
@@ -327,7 +332,6 @@ public class StudyService {
                     StudyGoal goal = StudyGoal.builder()
                         .content(g.getContent())
                         .goalType(GoalType.WEEKLY)
-//                        .activated(true)
                         .study(study)
                         .build();
                     study.addGoal(goal);


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
스터디 생성 시 StudyType이 Survival일 경우 생성 유저의 권한을 확인하는 로직을 추가했습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
findRole(memberId)를 통해 memberId의 유저의 권한을 가져옵니다.
스터디 생성요청 시 Survival 타입일경우 요청 맴버의 권한이 USER일 경우 HasNotRightException을 던저 생성을 막아두었습니다.

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
다른 로직이 더 필요할까요..?
