### PR TITLE
Hotfix: study info dup search

### DIFF
--- a/src/main/java/com/grepp/spring/app/model/member/repository/StudyMemberRepositoryCustom.java
+++ b/src/main/java/com/grepp/spring/app/model/member/repository/StudyMemberRepositoryCustom.java
@@ -30,9 +30,9 @@ public interface StudyMemberRepositoryCustom {
 
     int countByStudyId(Long studyId);
 
-    boolean existsActivatedByMemberIdAndStudyId(Long memberId, Long studyId);
+    boolean existStudyMember(Long memberId, Long studyId);
 
     Optional<StudyMember> findByStudyIdAndStudyMemberId(Long studyId, Long studyMemberId);
 
-    boolean existStudyMember(Long memberId, Long studyId);
+//    boolean existStudyMember(Long memberId, Long studyId);
 }

--- a/src/main/java/com/grepp/spring/app/model/member/repository/StudyMemberRepositoryCustomImpl.java
+++ b/src/main/java/com/grepp/spring/app/model/member/repository/StudyMemberRepositoryCustomImpl.java
@@ -154,7 +154,12 @@ public class StudyMemberRepositoryCustomImpl implements StudyMemberRepositoryCus
         Long count = queryFactory
             .select(sm.count())
             .from(sm)
-            .where(sm.study.studyId.eq(studyId))
+            .where(
+                sm.study.studyId.eq(studyId),
+                sm.activated.isTrue(),
+                sm.member.activated.isTrue(),
+                sm.study.activated.isTrue()
+            )
             .fetchOne();
         return count != null ? count.intValue() : 0;
     }

--- a/src/main/java/com/grepp/spring/app/model/member/repository/StudyMemberRepositoryCustomImpl.java
+++ b/src/main/java/com/grepp/spring/app/model/member/repository/StudyMemberRepositoryCustomImpl.java
@@ -169,11 +169,7 @@ public class StudyMemberRepositoryCustomImpl implements StudyMemberRepositoryCus
         Integer result = queryFactory
             .selectOne()
             .from(sm)
-            .where(
-                sm.member.id.eq(memberId),
-                sm.study.studyId.eq(studyId),
-                sm.activated.isTrue()
-            )
+            .where(sm.study.studyId.eq(studyId))
             .fetchFirst();
         return result != null;
     }

--- a/src/main/java/com/grepp/spring/app/model/member/repository/StudyMemberRepositoryCustomImpl.java
+++ b/src/main/java/com/grepp/spring/app/model/member/repository/StudyMemberRepositoryCustomImpl.java
@@ -169,7 +169,11 @@ public class StudyMemberRepositoryCustomImpl implements StudyMemberRepositoryCus
         Integer result = queryFactory
             .selectOne()
             .from(sm)
-            .where(sm.study.studyId.eq(studyId))
+            .where(
+                sm.study.studyId.eq(studyId),
+                sm.member.id.eq(memberId),
+                sm.activated.isTrue()
+            )
             .fetchFirst();
         return result != null;
     }

--- a/src/main/java/com/grepp/spring/app/model/member/repository/StudyMemberRepositoryCustomImpl.java
+++ b/src/main/java/com/grepp/spring/app/model/member/repository/StudyMemberRepositoryCustomImpl.java
@@ -165,7 +165,7 @@ public class StudyMemberRepositoryCustomImpl implements StudyMemberRepositoryCus
     }
 
     @Override
-    public boolean existsActivatedByMemberIdAndStudyId(Long memberId, Long studyId) {
+    public boolean existStudyMember(Long memberId, Long studyId) {
         Integer result = queryFactory
             .selectOne()
             .from(sm)
@@ -191,19 +191,19 @@ public class StudyMemberRepositoryCustomImpl implements StudyMemberRepositoryCus
     }
 
 
-    @Override
-    public boolean existStudyMember(Long memberId, Long studyId) {
-        return queryFactory
-            .selectOne()
-            .from(sm)
-            .where(
-                sm.member.id.eq(memberId),
-                sm.study.studyId.eq(studyId),
-                sm.activated.isTrue(),
-                sm.member.activated.isTrue(),
-                sm.study.activated.isTrue()
-            )
-            .fetchFirst() != null;
-    }
+//    @Override
+//    public boolean existStudyMember(Long memberId, Long studyId) {
+//        return queryFactory
+//            .selectOne()
+//            .from(sm)
+//            .where(
+//                sm.member.id.eq(memberId),
+//                sm.study.studyId.eq(studyId),
+//                sm.activated.isTrue(),
+//                sm.member.activated.isTrue(),
+//                sm.study.activated.isTrue()
+//            )
+//            .fetchFirst() != null;
+//    }
 
 }

--- a/src/main/java/com/grepp/spring/app/model/study/service/StudyMemberService.java
+++ b/src/main/java/com/grepp/spring/app/model/study/service/StudyMemberService.java
@@ -31,7 +31,7 @@ public class StudyMemberService {
     public void saveMember(Long studyId, Long memberId) {
 
         // 중복 등록 방지
-        if (studyMemberRepository.existsActivatedByMemberIdAndStudyId(memberId, studyId)) {
+        if (studyMemberRepository.existStudyMember(memberId, studyId)) {
             throw new AlreadyExistException(ResponseCode.ALREADY_EXIST);
         }
 
@@ -59,7 +59,7 @@ public class StudyMemberService {
             .orElseThrow(() -> new NotFoundException("회원 정보를 찾을 수 없습니다."));
 
         // 중복 가입 방지
-        if (studyMemberRepository.existsActivatedByMemberIdAndStudyId(memberId, studyId)) {
+        if (studyMemberRepository.existStudyMember(memberId, studyId)) {
             throw new AlreadyExistException(ResponseCode.ALREADY_EXIST);
         }
 

--- a/src/main/java/com/grepp/spring/app/model/study/service/StudyService.java
+++ b/src/main/java/com/grepp/spring/app/model/study/service/StudyService.java
@@ -45,7 +45,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
@@ -262,7 +261,7 @@ public class StudyService {
             throw new IllegalArgumentException("존재하지 않거나 비활성화된 스터디입니다.");
         }
 
-        return studyMemberRepository.existsActivatedByMemberIdAndStudyId(memberId, studyId);
+        return studyMemberRepository.existStudyMember(memberId, studyId);
     }
 
     // 스터디 멤버 조회


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
현재 신청 시 existsActivatedByMemberIdAndStudyId(Long memberId, Long studyId) 로직에서 조건이 부족해서 스터디맴버가 있음에도 제대로 찾지 못하는 오류를 발견해 해결하였습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
현재 해당 쿼리의 where절에서 sm의 studyId만 비교하고 memberId를 비교하지 않아 문제가 발생하고 있었습니다.
```
.where(
                sm.study.studyId.eq(studyId),
                sm.member.id.eq(memberId),
                sm.activated.isTrue()
            )
```
로직을 이렇게 변경하였습니다.

메서드 명도 existStudyMember로 변경해두고 기존의 existStudyMember는 주석처리해두었습니다.

테스트 환경 memberId 3이 서바이벌 스터디인 studyId2에 가입을 한 상황으로 
현재 보여주진않았지만 현재 맴버수가 5 -> 6으로 변경이 되었습니다.
https://github.com/user-attachments/assets/814f47e7-af36-4f0a-bfa3-6f949ee53c4e

가입 후 재 가입 시도 시 AlreadyExistException이 터지며 가입이 되지 않습니다.
https://github.com/user-attachments/assets/012e65f3-cea0-493d-bc22-bba1af63a570




