### PR TITLE
Feat: survival late apply exception

### DIFF
--- a/src/main/java/com/grepp/spring/app/model/member/repository/StudyMemberRepositoryCustom.java
+++ b/src/main/java/com/grepp/spring/app/model/member/repository/StudyMemberRepositoryCustom.java
@@ -32,6 +32,8 @@ public interface StudyMemberRepositoryCustom {
 
     boolean existStudyMember(Long memberId, Long studyId);
 
+    boolean existSurvivalMember(Long memberId, Long studyId);
+
     Optional<StudyMember> findByStudyIdAndStudyMemberId(Long studyId, Long studyMemberId);
 
 //    boolean existStudyMember(Long memberId, Long studyId);

--- a/src/main/java/com/grepp/spring/app/model/member/repository/StudyMemberRepositoryCustomImpl.java
+++ b/src/main/java/com/grepp/spring/app/model/member/repository/StudyMemberRepositoryCustomImpl.java
@@ -179,6 +179,19 @@ public class StudyMemberRepositoryCustomImpl implements StudyMemberRepositoryCus
     }
 
     @Override
+    public boolean existSurvivalMember(Long memberId, Long studyId) {
+        Integer result = queryFactory
+            .selectOne()
+            .from(sm)
+            .where(
+                sm.study.studyId.eq(studyId),
+                sm.member.id.eq(memberId)
+            )
+            .fetchFirst();
+        return result != null;
+    }
+
+    @Override
     public Optional<StudyMember> findByStudyIdAndStudyMemberId(Long studyId, Long studyMemberId) {
         StudyMember result = queryFactory
             .selectFrom(sm)

--- a/src/main/java/com/grepp/spring/app/model/study/service/StudyMemberService.java
+++ b/src/main/java/com/grepp/spring/app/model/study/service/StudyMemberService.java
@@ -61,7 +61,7 @@ public class StudyMemberService {
             .orElseThrow(() -> new NotFoundException("회원 정보를 찾을 수 없습니다."));
 
         // 시작일 이후이면 등록 금지
-        if(study.getStartDate().isBefore(LocalDate.now()) || study.getEndDate().isAfter(LocalDate.now())) {
+        if( study.getStartDate().isBefore(LocalDate.now()) ) {
             throw new LateApplyException(ResponseCode.BAD_REQUEST);
         }
         else if(study.getStartDate() == null) {

--- a/src/main/java/com/grepp/spring/app/model/study/service/StudyMemberService.java
+++ b/src/main/java/com/grepp/spring/app/model/study/service/StudyMemberService.java
@@ -10,8 +10,10 @@ import com.grepp.spring.app.model.study.entity.Study;
 import com.grepp.spring.app.model.study.repository.GoalAchievementRepository;
 import com.grepp.spring.app.model.study.repository.StudyRepository;
 import com.grepp.spring.infra.error.exceptions.AlreadyExistException;
+import com.grepp.spring.infra.error.exceptions.LateApplyException;
 import com.grepp.spring.infra.error.exceptions.NotFoundException;
 import com.grepp.spring.infra.response.ResponseCode;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -51,15 +53,23 @@ public class StudyMemberService {
     }
 
     @Transactional
-    public void applyToStudy(Long memberId, Long studyId) {
+    public void enrollInStudy(Long memberId, Long studyId) {
         Study study = studyRepository.findById(studyId)
             .orElseThrow(() -> new NotFoundException("해당 스터디가 존재하지 않습니다."));
 
         Member member = memberRepository.findById(memberId)
             .orElseThrow(() -> new NotFoundException("회원 정보를 찾을 수 없습니다."));
 
+        // 시작일 이후이면 등록 금지
+        if(study.getStartDate().isBefore(LocalDate.now()) || study.getEndDate().isAfter(LocalDate.now())) {
+            throw new LateApplyException(ResponseCode.BAD_REQUEST);
+        }
+        else if(study.getStartDate() == null) {
+            throw new NotFoundException("스터디 시작일 정보를 찾을 수 없습니다.");
+        }
+
         // 중복 가입 방지
-        if (studyMemberRepository.existStudyMember(memberId, studyId)) {
+        if (studyMemberRepository.existSurvivalMember(memberId, studyId)) {
             throw new AlreadyExistException(ResponseCode.ALREADY_EXIST);
         }
 

--- a/src/main/java/com/grepp/spring/app/model/study/service/StudyService.java
+++ b/src/main/java/com/grepp/spring/app/model/study/service/StudyService.java
@@ -295,9 +295,9 @@ public class StudyService {
         Member leader = memberRepository.findById(memberId)
             .orElseThrow(() -> new NotFoundException("회원 정보를 찾을 수 없습니다."));
 
-        if(req.getStudyType().equals(StudyType.SURVIVAL) && memberRepository.findRole(memberId) == Role.ROLE_USER) {
-            throw new HasNotRightException(ResponseCode.UNAUTHORIZED);
-        }
+//        if(req.getStudyType().equals(StudyType.SURVIVAL) && memberRepository.findRole(memberId) == Role.ROLE_USER) {
+//            throw new HasNotRightException(ResponseCode.UNAUTHORIZED);
+//        }
 
         // 1. 스터디 생성
         Study study = Study.builder()

--- a/src/main/java/com/grepp/spring/app/model/study/service/StudyService.java
+++ b/src/main/java/com/grepp/spring/app/model/study/service/StudyService.java
@@ -447,7 +447,7 @@ public class StudyService {
             );
         } else {
             // 서바이벌 스터디는 자동 승인
-            studyMemberService.applyToStudy(receiverId, studyId);
+            studyMemberService.enrollInStudy(receiverId, studyId);
         }
     }
 

--- a/src/main/java/com/grepp/spring/infra/error/RestApiExceptionAdvice.java
+++ b/src/main/java/com/grepp/spring/infra/error/RestApiExceptionAdvice.java
@@ -5,6 +5,7 @@ import com.grepp.spring.infra.error.exceptions.AlreadyExistException;
 import com.grepp.spring.infra.error.exceptions.CommonException;
 import com.grepp.spring.infra.error.exceptions.EarlierDateException;
 import com.grepp.spring.infra.error.exceptions.InsufficientRewardPointsException;
+import com.grepp.spring.infra.error.exceptions.LateApplyException;
 import com.grepp.spring.infra.error.exceptions.MailSendFailureException;
 import com.grepp.spring.infra.error.exceptions.NotFoundException;
 import com.grepp.spring.infra.error.exceptions.NullStateException;
@@ -284,6 +285,14 @@ public class RestApiExceptionAdvice {
 
     @ExceptionHandler(EarlierDateException.class)
     public ResponseEntity<CommonResponse<Void>> handlerEarlierDateException(EarlierDateException ex) {
+        log.error(ex.getMessage(), ex);
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(CommonResponse.error(ResponseCode.BAD_REQUEST.code(), ex.getMessage()));
+    }
+
+    @ExceptionHandler(LateApplyException.class)
+    public ResponseEntity<CommonResponse<Void>> handlerLateApplyException(LateApplyException ex) {
         log.error(ex.getMessage(), ex);
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)

--- a/src/main/java/com/grepp/spring/infra/error/RestApiExceptionAdvice.java
+++ b/src/main/java/com/grepp/spring/infra/error/RestApiExceptionAdvice.java
@@ -288,7 +288,7 @@ public class RestApiExceptionAdvice {
         log.error(ex.getMessage(), ex);
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
-            .body(CommonResponse.error(ResponseCode.BAD_REQUEST.code(), ex.getMessage()));
+            .body(CommonResponse.error(ResponseCode.BAD_REQUEST));
     }
 
     @ExceptionHandler(LateApplyException.class)
@@ -296,7 +296,7 @@ public class RestApiExceptionAdvice {
         log.error(ex.getMessage(), ex);
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
-            .body(CommonResponse.error(ResponseCode.BAD_REQUEST.code(), ex.getMessage()));
+            .body(CommonResponse.error(ResponseCode.BAD_REQUEST));
     }
 }
 

--- a/src/main/java/com/grepp/spring/infra/error/exceptions/LateApplyException.java
+++ b/src/main/java/com/grepp/spring/infra/error/exceptions/LateApplyException.java
@@ -1,0 +1,15 @@
+package com.grepp.spring.infra.error.exceptions;
+
+import com.grepp.spring.infra.response.ResponseCode;
+
+public class LateApplyException extends CommonException {
+
+
+    public LateApplyException(ResponseCode code) {
+        super(code);
+    }
+
+    public LateApplyException(ResponseCode code, Exception e) {
+        super(code, e);
+    }
+}


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
서바이벌 스터디에 한 해 시작일 이후에 신청 시 LayeApplyException을 던지도록 처리하였습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- `if(study.getStartDate().isBefore(LocalDate.now()))`
StarteDate가 현재 Date이전이거나 EndDate가 현재 Date 이후인 상황에서 예외를 던집니다.
LayeApplyException은 400 status로 code:"4000", message:"잘못된 요청입니다."
를 공통응답객체에 담아 반환합니다

- `else if(study.getStartDate() == null)`
스터디 시작일이 없다면 NotFoundException을 던집니다.

- `if (studyMemberRepository.existSurvivalMember(memberId, studyId))`
existMember()는 현재 스터디맴버가 삭제되지않은 경우만을 조회하기에 서바이벌 스터디와는 적합하지 않다 판단하여 
existSurvivalMember()를 만들어 탈락되어도 확인이 가능하도록 하였습니다.

<img width="1392" height="1483" alt="Screenshot 2025-07-30 at 11 56 17 AM" src="https://github.com/user-attachments/assets/a5debb67-3235-4184-868a-6d6c2a62fa64" />

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
메서드명 변경 applyToStudy -> enrollInStudy

