### PR TITLE
Hotfix: 소셜로그인 인증객체 생성하도록 변경

### DIFF
--- a/src/main/java/com/grepp/spring/infra/auth/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/grepp/spring/infra/auth/jwt/filter/JwtAuthenticationFilter.java
@@ -42,7 +42,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         List<String> excludePath = new ArrayList<>();
         excludePath.addAll(List.of("/favicon.ico", "/img", "/js","/css","/download"));
         excludePath.addAll(List.of("/error", "/api/member/exists", "/member/signin", "/member/signup"));
-        excludePath.addAll(List.of("/api/v1/auth/signup", "/api/v1/auth/login", "/api/v1/auth/reissue", "/api/v1/auth/email", "/api/v1/auth/oauth/first-regist"));
+        excludePath.addAll(List.of("/api/v1/auth/signup", "/api/v1/auth/login", "/api/v1/auth/reissue", "/api/v1/auth/email"));
         excludePath.addAll(List.of("/api/v1/studies/search", "/api/v1/studies/categories"));
         String path = request.getRequestURI();
         return excludePath.stream().anyMatch(path::startsWith);

--- a/src/main/java/com/grepp/spring/infra/config/security/SecurityConfig.java
+++ b/src/main/java/com/grepp/spring/infra/config/security/SecurityConfig.java
@@ -56,7 +56,7 @@ public class SecurityConfig {
                     .requestMatchers("/", "/error", "/oauth2/**",  "/login/**").permitAll()
                     // NOTE 아래의 스웨거관련 엔드포인트는 정식 배포 이후에 주석처리 해주세요
                     .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
-                    .requestMatchers("/api/v1/auth/signup", "/api/v1/auth/login", "/api/v1/auth/email/**", "/api/v1/auth/oauth/first-regist").permitAll()
+                    .requestMatchers("/api/v1/auth/signup", "/api/v1/auth/login", "/api/v1/auth/email/**").permitAll()
                     .requestMatchers("/api/v1/studies/search", "/api/v1/studies/categories").permitAll()
                     .requestMatchers(GET,"/api/v1/studies/*").permitAll()
                     .requestMatchers(GET,"/api/v1/studies/*/notification").permitAll()


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
현재 소셜 로그인 후 첫 로그인 시에 상세정보 입력에서 인증객체에 접근하는데 jwtAuthenticationFilter와 securifyFilterChain에서 해당 경로에 대한 예외 로직을 추가해 인증객체가 발생하지 않았던 문제가 있습니다.
이를 경로를 제거함으로써 해결했습니다.
정말 죄송합니다.
